### PR TITLE
Upgrading CleverTap-iOS-SDK to 3.6.0 to uses SDWebImage version 5.0

### DIFF
--- a/clevertap-react-native.podspec
+++ b/clevertap-react-native.podspec
@@ -18,6 +18,6 @@ Pod::Spec.new do |s|
   s.preserve_paths = 'LICENSE.md', 'README.md', 'package.json', 'index.js'
   s.source_files   = 'ios/CleverTapReact/*.{h,m}'
 
-  s.dependency 'CleverTap-iOS-SDK', '~> 3.5.0'
+  s.dependency 'CleverTap-iOS-SDK', '~> 3.6.0'
   s.dependency 'React'
 end

--- a/clevertap-react-native.podspec
+++ b/clevertap-react-native.podspec
@@ -18,6 +18,6 @@ Pod::Spec.new do |s|
   s.preserve_paths = 'LICENSE.md', 'README.md', 'package.json', 'index.js'
   s.source_files   = 'ios/CleverTapReact/*.{h,m}'
 
-  s.dependency 'CleverTap-iOS-SDK', '~> 3.6.0'
+  s.dependency 'CleverTap-iOS-SDK', '~> 3.5.0'
   s.dependency 'React'
 end

--- a/ios/CleverTapReact/CleverTapReact.m
+++ b/ios/CleverTapReact/CleverTapReact.m
@@ -1,9 +1,9 @@
 #import "CleverTapReact.h"
 #import "CleverTapReactManager.h"
-#import <CleverTapSDK/CleverTap.h>
-#import <CleverTapSDK/CleverTap+Inbox.h>
-#import <CleverTapSDK/CleverTapEventDetail.h>
-#import <CleverTapSDK/CleverTapUTMDetail.h>
+#import <CleverTap-iOS-SDK/CleverTap.h>
+#import <CleverTap-iOS-SDK/CleverTap+Inbox.h>
+#import <CleverTap-iOS-SDK/CleverTapEventDetail.h>
+#import <CleverTap-iOS-SDK/CleverTapUTMDetail.h>
 
 #import <UserNotifications/UserNotifications.h>
 #import <CoreLocation/CoreLocation.h>

--- a/ios/CleverTapReact/CleverTapReactManager.m
+++ b/ios/CleverTapReact/CleverTapReactManager.m
@@ -6,9 +6,9 @@
 
 #import <React/RCTLog.h>
 
-#import <CleverTapSDK/CleverTap.h>
-#import <CleverTapSDK/CleverTapSyncDelegate.h>
-#import <CleverTapSDK/CleverTapInAppNotificationDelegate.h>
+#import <CleverTap-iOS-SDK/CleverTap.h>
+#import <CleverTap-iOS-SDK/CleverTapSyncDelegate.h>
+#import <CleverTap-iOS-SDK/CleverTapInAppNotificationDelegate.h>
 
 
 @interface CleverTapReactManager() <CleverTapSyncDelegate, CleverTapInAppNotificationDelegate> {


### PR DESCRIPTION
CleverTap-iOS-SDK 3.5.0 uses a old versionn of SDWebImage, which conflicts with  "react-native-fast-image": "^7.0.2";