### PR TITLE
Change import style to pointed bracket

### DIFF
--- a/ios/CleverTapReact/CleverTapReact.m
+++ b/ios/CleverTapReact/CleverTapReact.m
@@ -6,11 +6,11 @@
 
 #import <React/RCTLog.h>
 
-#import "CleverTap.h"
-#import "CleverTap+Inbox.h"
-#import "CleverTap+ABTesting.h"
-#import "CleverTapEventDetail.h"
-#import "CleverTapUTMDetail.h"
+#import <CleverTapSDK/CleverTap.h>
+#import <CleverTapSDK/CleverTap+Inbox.h>
+#import <CleverTapSDK/CleverTap+ABTesting.h>
+#import <CleverTapSDK/CleverTapEventDetail.h>
+#import <CleverTapSDK/CleverTapUTMDetail.h>
 
 static NSDateFormatter *dateFormatter;
 

--- a/ios/CleverTapReact/CleverTapReactManager.m
+++ b/ios/CleverTapReact/CleverTapReactManager.m
@@ -6,13 +6,13 @@
 
 #import <React/RCTLog.h>
 
-#import "CleverTap.h"
-#import "CleverTap+Inbox.h"
-#import "CleverTap+ABTesting.h"
-#import "CleverTapEventDetail.h"
-#import "CleverTapUTMDetail.h"
-#import "CleverTapSyncDelegate.h"
-#import "CleverTapInAppNotificationDelegate.h"
+#import <CleverTapSDK/CleverTap.h>
+#import <CleverTapSDK/CleverTap+Inbox.h>
+#import <CleverTapSDK/CleverTap+ABTesting.h>
+#import <CleverTapSDK/CleverTapEventDetail.h>
+#import <CleverTapSDK/CleverTapUTMDetail.h>
+#import <CleverTapSDK/CleverTapSyncDelegate.h>
+#import <CleverTapSDK/CleverTapInAppNotificationDelegate.h>
 
 @interface CleverTapReactManager() <CleverTapSyncDelegate, CleverTapInAppNotificationDelegate> {
 }


### PR DESCRIPTION
Bug: `CleverTap.h not found solution in iOS`

Note: Android works.

Libraries used:
"clevertap-react-native": "^0.3.4",
"react-native": "0.59.10",

Solution:
Edit import style to pointed brackets