### PR TITLE
merge request, feat(device_id_callback) --> develop SDK-1033

### DIFF
--- a/Example/App.js
+++ b/Example/App.js
@@ -404,7 +404,7 @@ export default class App extends Component {
             {
                 expanded: false,
                 category_Name: "Attributions",
-                sub_Category: [{ id: 48, name: 'get CleverTap Attribution Identifier' }]
+                sub_Category: [{ id: 48, name: '(Deprecated) get CleverTap Attribution Identifier' }]
             },
             {
                 expanded: false,
@@ -507,8 +507,14 @@ removeValueForKey = () => {
 
 };
 getCleverTap_id = () => {
+    // Below method is deprecated since 0.6.0, please check index.js for deprecation, instead use CleverTap.getCleverTapID()
+    /*CleverTap.profileGetCleverTapID((err, res) => {
+        console.log('CleverTapID', res, err);
+        alert(`CleverTapID: \n ${res}`);
+    });*/
 
-    CleverTap.profileGetCleverTapID((err, res) => {
+    // Use below newly added method
+    CleverTap.getCleverTapID((err, res) => {
         console.log('CleverTapID', res, err);
         alert(`CleverTapID: \n ${res}`);
     });
@@ -858,7 +864,7 @@ profile_getProperty = () => {
 ///Attributions
 GetCleverTapAttributionIdentifier = () => {
 
-
+    // Below method is deprecated since 0.6.0, please check index.js for deprecation, use CleverTap.getCleverTapID(callback) instead
     //Default Instance
     CleverTap.profileGetCleverTapAttributionIdentifier((err, res) => {
         console.log('CleverTapAttributionIdentifier', res, err);

--- a/android/src/main/java/com/clevertap/react/CleverTapModule.java
+++ b/android/src/main/java/com/clevertap/react/CleverTapModule.java
@@ -6,6 +6,7 @@ import android.os.Build.VERSION;
 import android.os.Build.VERSION_CODES;
 import android.os.Bundle;
 import android.util.Log;
+import androidx.annotation.NonNull;
 import androidx.annotation.RequiresApi;
 import com.clevertap.android.sdk.CTFeatureFlagsListener;
 import com.clevertap.android.sdk.CTInboxListener;
@@ -21,6 +22,7 @@ import com.clevertap.android.sdk.displayunits.model.CleverTapDisplayUnit;
 import com.clevertap.android.sdk.events.EventDetail;
 import com.clevertap.android.sdk.featureFlags.CTFeatureFlagsController;
 import com.clevertap.android.sdk.inbox.CTInboxMessage;
+import com.clevertap.android.sdk.interfaces.OnInitCleverTapIDListener;
 import com.clevertap.android.sdk.product_config.CTProductConfigController;
 import com.clevertap.android.sdk.product_config.CTProductConfigListener;
 import com.clevertap.android.sdk.pushnotification.CTPushNotificationListener;
@@ -835,6 +837,21 @@ public class CleverTapModule extends ReactContextBaseJavaModule implements SyncL
             error = "CleverTap not initialized";
         }
         callbackWithErrorAndResult(callback, error, result);
+    }
+
+    @ReactMethod
+    public void getCleverTapID(final Callback callback) {
+        final CleverTapAPI clevertap = getCleverTapAPI();
+        if (clevertap != null) {
+            clevertap.getCleverTapID(new OnInitCleverTapIDListener() {
+                @Override
+                public void onInitCleverTapID(final String cleverTapID) {
+                    // Callback on main thread
+                    callbackWithErrorAndResult(callback, null, cleverTapID);
+                }
+
+            });
+        }
     }
 
     @ReactMethod

--- a/android/src/main/java/com/clevertap/react/CleverTapModule.java
+++ b/android/src/main/java/com/clevertap/react/CleverTapModule.java
@@ -6,7 +6,6 @@ import android.os.Build.VERSION;
 import android.os.Build.VERSION_CODES;
 import android.os.Bundle;
 import android.util.Log;
-import androidx.annotation.NonNull;
 import androidx.annotation.RequiresApi;
 import com.clevertap.android.sdk.CTFeatureFlagsListener;
 import com.clevertap.android.sdk.CTInboxListener;
@@ -851,6 +850,9 @@ public class CleverTapModule extends ReactContextBaseJavaModule implements SyncL
                 }
 
             });
+        } else {
+            String error = ErrorMessages.CLEVERTAP_NOT_INITIALIZED.getErrorMessage();
+            callbackWithErrorAndResult(callback, error, null);
         }
     }
 
@@ -1035,9 +1037,8 @@ public class CleverTapModule extends ReactContextBaseJavaModule implements SyncL
         }
         try {
             clevertap.recordScreen(screenName);
-        }catch (NullPointerException npe)
-        {
-            Log.e(TAG,"Something went wrong in native SDK!");
+        } catch (NullPointerException npe) {
+            Log.e(TAG, "Something went wrong in native SDK!");
             npe.printStackTrace();
         }
     }

--- a/index.js
+++ b/index.js
@@ -78,7 +78,7 @@ var CleverTap = {
     },
 
     /**
-    *  Deprecated - Since version 5.0.0. Use removeListener(eventName) instead
+    *  Deprecated - Since version 0.5.0. Use removeListener(eventName) instead
     *  Remove all event listeners
     */
     removeListeners: function () {
@@ -323,6 +323,7 @@ var CleverTap = {
     },
 
     /**
+     * Deprecated - Since version 0.6.0. Use getCleverTapID(callback) instead
     * Get a unique CleverTap identifier suitable for use with install attribution providers
     * @param {function(err, res)} callback that returns a string res
     */
@@ -331,6 +332,7 @@ var CleverTap = {
     },
 
     /**
+     * Deprecated - Since version 0.6.0. Use getCleverTapID(callback) instead
     * Get the user profile's CleverTap identifier value
     * @param {function(err, res)} callback that returns a string res
     */
@@ -695,6 +697,15 @@ var CleverTap = {
     */
     getFeatureFlag: function (name, defaultValue, callback) {
         callWithCallback('getFeatureFlag', [name, defaultValue], callback);
+    },
+
+    /**
+     * Returns a unique identifier through callback by which CleverTap identifies this user
+     *
+     * @param {function(err, res)} non-null callback to retrieve identifier
+     */
+    getCleverTapID: function (callback) {
+        callWithCallback('getCleverTapID', null, callback);
     },
 
     /**


### PR DESCRIPTION
- Deprecates `profileGetCleverTapID()` and `profileGetCleverTapAttributionIdentifier()`
- Adds a new public method `getCleverTapID()` as an alternative to above deprecated methods