### PR TITLE
Release v0.6.0

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,1 +1,2 @@
 Example
+.idea

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 Change Log
 ==========
 
+Version 0.6.0 *(30th August 2021)*
+-------------------------------------------
+- Adds public methods for suspending/discarding & resuming InApp Notifications
+- Adds public methods to increment/decrement values set via User properties
+- Deprecates `profileGetCleverTapID()` and `profileGetCleverTapAttributionIdentifier()`
+- Adds a new public method `getCleverTapID()` as an alternative to above deprecated methods
+
 Version 0.5.2 *(20th July 2021)*
 -------------------------------------------
 - Supports CleverTap Android SDK `v4.2.0`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,13 @@
 Change Log
 ==========
 
-Version 0.6.0 *(30th August 2021)*
+Version 0.6.0 *(3rd September 2021)*
 -------------------------------------------
 - Adds public methods for suspending/discarding & resuming InApp Notifications
 - Adds public methods to increment/decrement values set via User properties
 - Deprecates `profileGetCleverTapID()` and `profileGetCleverTapAttributionIdentifier()`
 - Adds a new public method `getCleverTapID()` as an alternative to above deprecated methods
+- Supports CleverTap iOS SDK `v3.10.0`
 
 Version 0.5.2 *(20th July 2021)*
 -------------------------------------------

--- a/Example/App.js
+++ b/Example/App.js
@@ -211,6 +211,15 @@ class Expandable_ListView extends Component {
             case 45:
                 getFeatureFlag();
                 break;
+            case 450:
+                CleverTap.suspendInAppNotifications();
+                break;
+            case 451:
+                CleverTap.discardInAppNotifications();
+                break;
+            case 452:
+                CleverTap.resumeInAppNotifications();
+                break;
             case 46:
                 enablePersonalization();
                 break;
@@ -406,6 +415,10 @@ export default class App extends Component {
             },
             {
                 expanded: false, category_Name: "Feature Flag", sub_Category: [{ id: 45, name: 'getFeatureFlag' }]
+            },
+            {
+                expanded: false, category_Name: "InApp Controls", sub_Category: [{ id: 450, name: 'suspendInAppNotifications' }
+                ,{ id: 451, name: 'discardInAppNotifications' },{ id: 452, name: 'resumeInAppNotifications' }]
             },
             {
                 expanded: false,

--- a/Example/App.js
+++ b/Example/App.js
@@ -72,6 +72,16 @@ class Expandable_ListView extends Component {
             case 5:
                 CleverTap.profileAddMultiValueForKey('d', 'letters');
                 break;
+            case 500:
+                CleverTap.profileIncrementValueForKey('score', Number('10'));
+                CleverTap.profileIncrementValueForKey('PI_Float', 3.141);
+                CleverTap.profileIncrementValueForKey('PI_Double', 3.141592653589793);
+                break;
+            case 501:
+                CleverTap.profileDecrementValueForKey('score', 10);
+                CleverTap.profileDecrementValueForKey('PI_Float', 3.141);
+                CleverTap.profileDecrementValueForKey('PI_Double', 3.141592653589793);
+                break;
             case 6:
                 onUser_Login();
                 break;
@@ -317,7 +327,8 @@ export default class App extends Component {
                 sub_Category: [{ id: 1, name: 'pushProfile' }, { id: 2, name: 'set Multi Values For Key' }, {
                     id: 3,
                     name: 'removeMultiValueForKey'
-                }, { id: 4, name: 'removeValueForKey' }, { id: 5, name: 'addMultiValueForKey' }]
+                }, { id: 4, name: 'removeValueForKey' }, { id: 5, name: 'addMultiValueForKey' }
+                    , { id: 500, name: 'Increment Value' }, { id: 501, name: 'Decrement Value' }]
             },
 
             {

--- a/Example/App.js
+++ b/Example/App.js
@@ -66,21 +66,21 @@ class Expandable_ListView extends Component {
             case 3:
                 CleverTap.profileRemoveMultiValueForKey('b', 'letters');
                 break;
-            case 4: //Removing a Value from the Multiple Values
+            case 4:
                 CleverTap.profileRemoveMultiValueForKey('b', 'letters');
                 break;
             case 5:
                 CleverTap.profileAddMultiValueForKey('d', 'letters');
                 break;
             case 500:
-                CleverTap.profileIncrementValueForKey(Number('10'),'score');
+                CleverTap.profileIncrementValueForKey(10, 'score');
                 CleverTap.profileIncrementValueForKey(3.141,'PI_Float');
                 CleverTap.profileIncrementValueForKey(3.141592653589793,'PI_Double');
                 break;
             case 501:
-                CleverTap.profileDecrementValueForKey(10,'score');
-                CleverTap.profileDecrementValueForKey(3.141,'PI_Float');
-                CleverTap.profileDecrementValueForKey(3.141592653589793,'PI_Double');
+                CleverTap.profileDecrementValueForKey(10, 'score');
+                CleverTap.profileDecrementValueForKey(3.141, 'PI_Float');
+                CleverTap.profileDecrementValueForKey(3.141592653589793, 'PI_Double');
                 break;
             case 6:
                 onUser_Login();
@@ -309,7 +309,7 @@ export default class App extends Component {
         // Listener to handle incoming deep links
         Linking.addEventListener('url', _handleOpenUrl);
 
-        // this handles the case where a deep link launches the application
+        /// this handles the case where a deep link launches the application
         Linking.getInitialURL().then((url) => {
             if (url) {
                 console.log('launch url', url);
@@ -418,7 +418,7 @@ export default class App extends Component {
             },
             {
                 expanded: false, category_Name: "InApp Controls", sub_Category: [{ id: 450, name: 'suspendInAppNotifications' }
-                ,{ id: 451, name: 'discardInAppNotifications' },{ id: 452, name: 'resumeInAppNotifications' }]
+                    , { id: 451, name: 'discardInAppNotifications' }, { id: 452, name: 'resumeInAppNotifications' }]
             },
             {
                 expanded: false,
@@ -1064,7 +1064,7 @@ const styles = StyleSheet.create({
     },
 
     button_Text: {
-        width:'100%',
+        width: '100%',
         textAlign: 'center',
         color: '#000',
         fontWeight: 'bold',
@@ -1072,7 +1072,7 @@ const styles = StyleSheet.create({
     },
 
     setSubCategoryFontSizeOne: {
-        fontSize: 18 
+        fontSize: 18
     },
 
 });

--- a/Example/App.js
+++ b/Example/App.js
@@ -73,14 +73,14 @@ class Expandable_ListView extends Component {
                 CleverTap.profileAddMultiValueForKey('d', 'letters');
                 break;
             case 500:
-                CleverTap.profileIncrementValueForKey('score', Number('10'));
-                CleverTap.profileIncrementValueForKey('PI_Float', 3.141);
-                CleverTap.profileIncrementValueForKey('PI_Double', 3.141592653589793);
+                CleverTap.profileIncrementValueForKey(Number('10'),'score');
+                CleverTap.profileIncrementValueForKey(3.141,'PI_Float');
+                CleverTap.profileIncrementValueForKey(3.141592653589793,'PI_Double');
                 break;
             case 501:
-                CleverTap.profileDecrementValueForKey('score', 10);
-                CleverTap.profileDecrementValueForKey('PI_Float', 3.141);
-                CleverTap.profileDecrementValueForKey('PI_Double', 3.141592653589793);
+                CleverTap.profileDecrementValueForKey(10,'score');
+                CleverTap.profileDecrementValueForKey(3.141,'PI_Float');
+                CleverTap.profileDecrementValueForKey(3.141592653589793,'PI_Double');
                 break;
             case 6:
                 onUser_Login();

--- a/Example/App.js
+++ b/Example/App.js
@@ -415,7 +415,7 @@ export default class App extends Component {
             {
                 expanded: false,
                 category_Name: "Attributions",
-                sub_Category: [{ id: 48, name: 'get CleverTap Attribution Identifier' }]
+                sub_Category: [{ id: 48, name: '(Deprecated) get CleverTap Attribution Identifier' }]
             },
             {
                 expanded: false,
@@ -518,8 +518,14 @@ removeValueForKey = () => {
 
 };
 getCleverTap_id = () => {
+    // Below method is deprecated since 0.6.0, please check index.js for deprecation, instead use CleverTap.getCleverTapID()
+    /*CleverTap.profileGetCleverTapID((err, res) => {
+        console.log('CleverTapID', res, err);
+        alert(`CleverTapID: \n ${res}`);
+    });*/
 
-    CleverTap.profileGetCleverTapID((err, res) => {
+    // Use below newly added method
+    CleverTap.getCleverTapID((err, res) => {
         console.log('CleverTapID', res, err);
         alert(`CleverTapID: \n ${res}`);
     });
@@ -869,7 +875,7 @@ profile_getProperty = () => {
 ///Attributions
 GetCleverTapAttributionIdentifier = () => {
 
-
+    // Below method is deprecated since 0.6.0, please check index.js for deprecation, use CleverTap.getCleverTapID(callback) instead
     //Default Instance
     CleverTap.profileGetCleverTapAttributionIdentifier((err, res) => {
         console.log('CleverTapAttributionIdentifier', res, err);

--- a/Example/ios/Example.xcodeproj/project.pbxproj
+++ b/Example/ios/Example.xcodeproj/project.pbxproj
@@ -7,11 +7,11 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		0ED7D526153148432ADDC432 /* libPods-Example.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 7C2F7457C4A128FFD956BCCB /* libPods-Example.a */; };
 		13B07FBC1A68108700A75B9A /* AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 13B07FB01A68108700A75B9A /* AppDelegate.m */; };
 		13B07FBF1A68108700A75B9A /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 13B07FB51A68108700A75B9A /* Images.xcassets */; };
 		13B07FC11A68108700A75B9A /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 13B07FB71A68108700A75B9A /* main.m */; };
 		81AB9BB82411601600AC10FF /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 81AB9BB72411601600AC10FF /* LaunchScreen.storyboard */; };
+		9DC8424141B4358267A0B400 /* libPods-Example.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 2701590A358AE9E74F23A796 /* libPods-Example.a */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -21,11 +21,11 @@
 		13B07FB51A68108700A75B9A /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; name = Images.xcassets; path = Example/Images.xcassets; sourceTree = "<group>"; };
 		13B07FB61A68108700A75B9A /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = Info.plist; path = Example/Info.plist; sourceTree = "<group>"; };
 		13B07FB71A68108700A75B9A /* main.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = main.m; path = Example/main.m; sourceTree = "<group>"; };
+		2701590A358AE9E74F23A796 /* libPods-Example.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-Example.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		494B16C126B01FD7008F32F7 /* Example.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; name = Example.entitlements; path = Example/Example.entitlements; sourceTree = "<group>"; };
-		7C2F7457C4A128FFD956BCCB /* libPods-Example.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-Example.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		81AB9BB72411601600AC10FF /* LaunchScreen.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; name = LaunchScreen.storyboard; path = Example/LaunchScreen.storyboard; sourceTree = "<group>"; };
-		8CCD02BA391B3B061E22FE30 /* Pods-Example.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Example.release.xcconfig"; path = "Target Support Files/Pods-Example/Pods-Example.release.xcconfig"; sourceTree = "<group>"; };
-		BCA6A9B9E7C00E6EAC8C42D4 /* Pods-Example.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Example.debug.xcconfig"; path = "Target Support Files/Pods-Example/Pods-Example.debug.xcconfig"; sourceTree = "<group>"; };
+		CFC784233BA6FB4CD79E3A31 /* Pods-Example.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Example.debug.xcconfig"; path = "Target Support Files/Pods-Example/Pods-Example.debug.xcconfig"; sourceTree = "<group>"; };
+		D5200CA3BDDE01218215BB77 /* Pods-Example.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Example.release.xcconfig"; path = "Target Support Files/Pods-Example/Pods-Example.release.xcconfig"; sourceTree = "<group>"; };
 		ED297162215061F000B7C4FE /* JavaScriptCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = JavaScriptCore.framework; path = System/Library/Frameworks/JavaScriptCore.framework; sourceTree = SDKROOT; };
 /* End PBXFileReference section */
 
@@ -34,7 +34,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				0ED7D526153148432ADDC432 /* libPods-Example.a in Frameworks */,
+				9DC8424141B4358267A0B400 /* libPods-Example.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -59,7 +59,7 @@
 			isa = PBXGroup;
 			children = (
 				ED297162215061F000B7C4FE /* JavaScriptCore.framework */,
-				7C2F7457C4A128FFD956BCCB /* libPods-Example.a */,
+				2701590A358AE9E74F23A796 /* libPods-Example.a */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -67,8 +67,8 @@
 		7168044AA71FBFBA4A3B8E24 /* Pods */ = {
 			isa = PBXGroup;
 			children = (
-				BCA6A9B9E7C00E6EAC8C42D4 /* Pods-Example.debug.xcconfig */,
-				8CCD02BA391B3B061E22FE30 /* Pods-Example.release.xcconfig */,
+				CFC784233BA6FB4CD79E3A31 /* Pods-Example.debug.xcconfig */,
+				D5200CA3BDDE01218215BB77 /* Pods-Example.release.xcconfig */,
 			);
 			path = Pods;
 			sourceTree = "<group>";
@@ -109,13 +109,13 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 13B07F931A680F5B00A75B9A /* Build configuration list for PBXNativeTarget "Example" */;
 			buildPhases = (
-				6DC0FD03AA14172B67400905 /* [CP] Check Pods Manifest.lock */,
+				855E3FCFBC9FA3705E21D6BE /* [CP] Check Pods Manifest.lock */,
 				FD10A7F022414F080027D42C /* Start Packager */,
 				13B07F871A680F5B00A75B9A /* Sources */,
 				13B07F8C1A680F5B00A75B9A /* Frameworks */,
 				13B07F8E1A680F5B00A75B9A /* Resources */,
 				00DD1BFF1BD5951E006B06BC /* Bundle React Native code and images */,
-				D411CCF697F5C7ECAB356675 /* [CP] Copy Pods Resources */,
+				2D940EE659B7722400DA5FE3 /* [CP] Copy Pods Resources */,
 			);
 			buildRules = (
 			);
@@ -184,7 +184,24 @@
 			shellPath = /bin/sh;
 			shellScript = "set -e\n\nexport NODE_BINARY=node\n../node_modules/react-native/scripts/react-native-xcode.sh\n";
 		};
-		6DC0FD03AA14172B67400905 /* [CP] Check Pods Manifest.lock */ = {
+		2D940EE659B7722400DA5FE3 /* [CP] Copy Pods Resources */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Example/Pods-Example-resources-${CONFIGURATION}-input-files.xcfilelist",
+			);
+			name = "[CP] Copy Pods Resources";
+			outputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Example/Pods-Example-resources-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Example/Pods-Example-resources.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		855E3FCFBC9FA3705E21D6BE /* [CP] Check Pods Manifest.lock */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -204,23 +221,6 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
-			showEnvVarsInLog = 0;
-		};
-		D411CCF697F5C7ECAB356675 /* [CP] Copy Pods Resources */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-Example/Pods-Example-resources-${CONFIGURATION}-input-files.xcfilelist",
-			);
-			name = "[CP] Copy Pods Resources";
-			outputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-Example/Pods-Example-resources-${CONFIGURATION}-output-files.xcfilelist",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Example/Pods-Example-resources.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
 		FD10A7F022414F080027D42C /* Start Packager */ = {
@@ -259,7 +259,7 @@
 /* Begin XCBuildConfiguration section */
 		13B07F941A680F5B00A75B9A /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = BCA6A9B9E7C00E6EAC8C42D4 /* Pods-Example.debug.xcconfig */;
+			baseConfigurationReference = CFC784233BA6FB4CD79E3A31 /* Pods-Example.debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;
@@ -288,7 +288,7 @@
 		};
 		13B07F951A680F5B00A75B9A /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 8CCD02BA391B3B061E22FE30 /* Pods-Example.release.xcconfig */;
+			baseConfigurationReference = D5200CA3BDDE01218215BB77 /* Pods-Example.release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;

--- a/Example/package-lock.json
+++ b/Example/package-lock.json
@@ -2638,9 +2638,8 @@
       }
     },
     "clevertap-react-native": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/clevertap-react-native/-/clevertap-react-native-0.5.2.tgz",
-      "integrity": "sha512-1EV7AXp4Fqfz/VRsL1GgqnNEnsjtmCzaQZCuYUSq4YTzxI9IsHs16NUxB2VJVOC2oqbi8w5gsj1kwKMISC5WCw==",
+      "version": "git+https://github.com/CleverTap/clevertap-react-native.git#98137c15189fddae1bff0d03bb582b0a69a767f9",
+      "from": "git+https://github.com/CleverTap/clevertap-react-native.git#develop",
       "requires": {
         "extract-zip": "^1.6.6"
       }

--- a/Example/package.json
+++ b/Example/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "@react-navigation/drawer": "^5.12.5",
     "@react-navigation/native": "^6.0.0-next.1",
-    "clevertap-react-native": "^0.5.2",
+    "clevertap-react-native": "git+https://github.com/CleverTap/clevertap-react-native.git#develop",
     "react": "17.0.1",
     "react-native": "0.64.1",
     "react-native-drawer": "^2.5.1",

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -21,8 +21,8 @@ android {
     defaultConfig {
         minSdkVersion 16
         targetSdkVersion 30
-        versionCode 52
-        versionName "0.5.2"
+        versionCode 60
+        versionName "0.6.0"
     }
     buildTypes {
         release {

--- a/android/src/main/java/com/clevertap/react/CleverTapModule.java
+++ b/android/src/main/java/com/clevertap/react/CleverTapModule.java
@@ -1233,7 +1233,7 @@ public class CleverTapModule extends ReactContextBaseJavaModule implements SyncL
     // Increment/Decrement Operator
 
     @ReactMethod
-    public void incrementValue(String key,Double value) {
+    public void profileIncrementValueForKey(Double value,String key) {
         CleverTapAPI cleverTap = getCleverTapAPI();
         if (cleverTap != null) {
             cleverTap.incrementValue(key, value);
@@ -1241,7 +1241,7 @@ public class CleverTapModule extends ReactContextBaseJavaModule implements SyncL
     }
 
     @ReactMethod
-    public void decrementValue(String key,Double value) {
+    public void profileDecrementValueForKey(Double value,String key) {
         CleverTapAPI cleverTap = getCleverTapAPI();
         if (cleverTap != null) {
             cleverTap.decrementValue(key, value);

--- a/android/src/main/java/com/clevertap/react/CleverTapModule.java
+++ b/android/src/main/java/com/clevertap/react/CleverTapModule.java
@@ -1248,6 +1248,32 @@ public class CleverTapModule extends ReactContextBaseJavaModule implements SyncL
         }
     }
 
+    // InApp Controls
+
+    @ReactMethod
+    public void suspendInAppNotifications() {
+        CleverTapAPI cleverTap = getCleverTapAPI();
+        if (cleverTap != null) {
+            cleverTap.suspendInAppNotifications();
+        }
+    }
+
+    @ReactMethod
+    public void discardInAppNotifications() {
+        CleverTapAPI cleverTap = getCleverTapAPI();
+        if (cleverTap != null) {
+            cleverTap.discardInAppNotifications();
+        }
+    }
+
+    @ReactMethod
+    public void resumeInAppNotifications() {
+        CleverTapAPI cleverTap = getCleverTapAPI();
+        if (cleverTap != null) {
+            cleverTap.resumeInAppNotifications();
+        }
+    }
+
     /**
      * result must be primitive, String or com.facebook.react.bridge.WritableArray/WritableMap
      * see https://github.com/facebook/react-native/issues/3101#issuecomment-143954448

--- a/android/src/main/java/com/clevertap/react/CleverTapModule.java
+++ b/android/src/main/java/com/clevertap/react/CleverTapModule.java
@@ -21,6 +21,7 @@ import com.clevertap.android.sdk.displayunits.model.CleverTapDisplayUnit;
 import com.clevertap.android.sdk.events.EventDetail;
 import com.clevertap.android.sdk.featureFlags.CTFeatureFlagsController;
 import com.clevertap.android.sdk.inbox.CTInboxMessage;
+import com.clevertap.android.sdk.interfaces.OnInitCleverTapIDListener;
 import com.clevertap.android.sdk.product_config.CTProductConfigController;
 import com.clevertap.android.sdk.product_config.CTProductConfigListener;
 import com.clevertap.android.sdk.pushnotification.CTPushNotificationListener;
@@ -838,6 +839,24 @@ public class CleverTapModule extends ReactContextBaseJavaModule implements SyncL
     }
 
     @ReactMethod
+    public void getCleverTapID(final Callback callback) {
+        final CleverTapAPI clevertap = getCleverTapAPI();
+        if (clevertap != null) {
+            clevertap.getCleverTapID(new OnInitCleverTapIDListener() {
+                @Override
+                public void onInitCleverTapID(final String cleverTapID) {
+                    // Callback on main thread
+                    callbackWithErrorAndResult(callback, null, cleverTapID);
+                }
+
+            });
+        } else {
+            String error = ErrorMessages.CLEVERTAP_NOT_INITIALIZED.getErrorMessage();
+            callbackWithErrorAndResult(callback, error, null);
+        }
+    }
+
+    @ReactMethod
     public void profileGetProperty(String propertyName, Callback callback) {
         String error = null;
         Object result = null;
@@ -1018,9 +1037,8 @@ public class CleverTapModule extends ReactContextBaseJavaModule implements SyncL
         }
         try {
             clevertap.recordScreen(screenName);
-        }catch (NullPointerException npe)
-        {
-            Log.e(TAG,"Something went wrong in native SDK!");
+        } catch (NullPointerException npe) {
+            Log.e(TAG, "Something went wrong in native SDK!");
             npe.printStackTrace();
         }
     }

--- a/android/src/main/java/com/clevertap/react/CleverTapModule.java
+++ b/android/src/main/java/com/clevertap/react/CleverTapModule.java
@@ -1212,6 +1212,24 @@ public class CleverTapModule extends ReactContextBaseJavaModule implements SyncL
         }
     }
 
+    // Increment/Decrement Operator
+
+    @ReactMethod
+    public void incrementValue(String key,Double value) {
+        CleverTapAPI cleverTap = getCleverTapAPI();
+        if (cleverTap != null) {
+            cleverTap.incrementValue(key, value);
+        }
+    }
+
+    @ReactMethod
+    public void decrementValue(String key,Double value) {
+        CleverTapAPI cleverTap = getCleverTapAPI();
+        if (cleverTap != null) {
+            cleverTap.decrementValue(key, value);
+        }
+    }
+
     /**
      * result must be primitive, String or com.facebook.react.bridge.WritableArray/WritableMap
      * see https://github.com/facebook/react-native/issues/3101#issuecomment-143954448

--- a/clevertap-react-native.podspec
+++ b/clevertap-react-native.podspec
@@ -18,6 +18,6 @@ Pod::Spec.new do |s|
   s.preserve_paths = 'LICENSE.md', 'README.md', 'package.json', 'index.js'
   s.source_files   = 'ios/CleverTapReact/*.{h,m}'
 
-  s.dependency 'CleverTap-iOS-SDK', '3.9.3'
+  s.dependency 'CleverTap-iOS-SDK', '3.10.0'
   s.dependency 'React'
 end

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -52,6 +52,18 @@ CleverTap.profileGetCleverTapID((err, res) => {
 CleverTap.setLocation(34.15, -118.20);
 ```
 
+#### Increment a User Profile property
+
+```javascript 
+CleverTap.profileIncrementValueForKey(1, "score");
+```
+
+#### Decrement a User Profile property
+
+```javascript 
+CleverTap.profileDecrementValueForKey(1, "score");
+```
+
 -----------
 
 ## User Events
@@ -290,7 +302,7 @@ CleverTap.resetProductConfig();
 
 ```javascript 
 CleverTap.getLastFetchTimeStampInMillis((err, res) => {
-        onsole.log('LastFetchTimeStampInMillis in string: ', res, err);
+        console.log('LastFetchTimeStampInMillis in string: ', res, err);
 });		
 ```
 
@@ -301,6 +313,16 @@ CleverTap.getLastFetchTimeStampInMillis((err, res) => {
 ```javascript 
 CleverTap.getFeatureFlag('is_dark_mode', false, (err, res) => {
 	console.log('FF is_dark_mode val in boolean :', res, err);
+});
+```
+
+## CleverTap ID
+
+#### Get CleverTap ID
+
+```javascript 
+CleverTap.getCleverTapID((err, res) => {
+        console.log('CleverTapID', res, err);
 });
 ```
 
@@ -338,6 +360,28 @@ CleverTap.profileGetProperty('Name', (err, res) => {
 CleverTap.profileGetCleverTapAttributionIdentifier((err, res) => {
          console.log('CleverTapAttributionIdentifier', res, err);
 });
+```
+
+-----------
+
+## InApp Notification Controls
+
+#### Suspend InApp Notifications
+
+```javascript 
+CleverTap.suspendInAppNotifications();
+```
+
+#### Discard InApp Notifications
+
+```javascript 
+CleverTap.discardInAppNotifications();
+```
+
+#### Resume InApp Notifications
+
+```javascript 
+CleverTap.resumeInAppNotifications();
 ```
 
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -274,16 +274,25 @@
   export function profileGetProperty(propertyName: string, callback: Callback): void;
 
   /**
+   * Deprecated - Since version 0.6.0. Use getCleverTapID(callback) instead
    * Get a unique CleverTap identifier suitable for use with install attribution providers.
    * calls back with unique CleverTap attribution identifier
    */
   export function profileGetCleverTapAttributionIdentifier(callback: Callback): void;
 
   /**
+   * Deprecated - Since version 0.6.0. Use getCleverTapID(callback) instead
    * Get User Profile CleverTapID
    * calls back with CleverTapID or false
    */
   export function profileGetCleverTapID(callback: Callback): void;
+
+  /**
+   * Returns a unique identifier through callback by which CleverTap identifies this user
+   *
+   * @param {function(err, res)} non-null callback to retrieve identifier
+   */
+  export function getCleverTapID(callback: Callback): void;
 
   /**
    * Remove the property specified by key from the user profile

--- a/index.d.ts
+++ b/index.d.ts
@@ -325,6 +325,26 @@
    */
   export function profileRemoveMultiValuesForKey(values: any, key: string): void;
 
+  /*******************************
+   * Increment/Decrement Operators
+   *******************************/
+
+   /**
+   * This method is used to increment the given value
+   *
+   * @param value {Number} can be int,double or float only (NaN,Infinity etc not supported)
+   * @param key   {string} profile property
+   */
+  export function profileIncrementValueForKey(value:number, key:string): void;
+
+  /**
+   * This method is used to decrement the given value
+   *
+   * @param value {Number} can be int,double or float only (NaN,Infinity etc not supported)
+   * @param key   {string} profile property
+   */
+  export function profileDecrementValueForKey(value:number, key:string): void;
+
   /*******************
    * Session
    ******************/
@@ -543,25 +563,6 @@
     defaultValue: boolean,
     callback: Callback): void;
 
-  /*******************************
-   * Increment/Decrement Operators
-   *******************************/
-
-  /**
-   * This method is used to increment the given value
-   *
-   * @param key   {string} profile property
-   * @param value {Number} can be int,double or float only (NaN,Infinity etc not supported)
-   */
-  export function profileIncrementValueForKey(key:string,value:number): void;
-
-  /**
-   * This method is used to decrement the given value
-   *
-   * @param key   {string} profile property
-   * @param value {Number} can be int,double or float only (NaN,Infinity etc not supported)
-   */
-  export function profileDecrementValueForKey(key:string,value:number): void;
 
   /*******************
    * Developer Options

--- a/index.d.ts
+++ b/index.d.ts
@@ -543,6 +543,26 @@
     defaultValue: boolean,
     callback: Callback): void;
 
+  /*******************************
+   * Increment/Decrement Operators
+   *******************************/
+
+  /**
+   * This method is used to increment the given value
+   *
+   * @param key   {string} profile property
+   * @param value {Number} can be int,double or float only (NaN,Infinity etc not supported)
+   */
+  export function profileIncrementValueForKey(key:string,value:number): void;
+
+  /**
+   * This method is used to decrement the given value
+   *
+   * @param key   {string} profile property
+   * @param value {Number} can be int,double or float only (NaN,Infinity etc not supported)
+   */
+  export function profileDecrementValueForKey(key:string,value:number): void;
+
   /*******************
    * Developer Options
    ******************/

--- a/index.d.ts
+++ b/index.d.ts
@@ -565,6 +565,36 @@
 
 
   /*******************
+   * InApp Controls
+   ******************/
+
+  /**
+   * Suspends display of InApp Notifications.
+   * The InApp Notifications are queued once this method is called
+   * and will be displayed once resumeInAppNotifications() is called.
+   */
+  export function suspendInAppNotifications(): void;
+
+  /**
+   * Suspends the display of InApp Notifications and discards any new InApp Notifications to be shown
+   * after this method is called.
+   * The InApp Notifications will be displayed only once resumeInAppNotifications() is called.
+   */
+  export function discardInAppNotifications(): void;
+
+  /**
+   * Resumes display of InApp Notifications.
+   *
+   * If suspendInAppNotifications() was called previously, calling this method will instantly show
+   * all queued InApp Notifications and also resume InApp Notifications on events raised after this
+   * method is called.
+   *
+   * If discardInAppNotifications() was called previously, calling this method will only resume
+   * InApp Notifications on events raised after this method is called.
+   */
+  export function resumeInAppNotifications(): void;
+
+  /*******************
    * Developer Options
    ******************/
   /**

--- a/index.js
+++ b/index.js
@@ -78,7 +78,7 @@ var CleverTap = {
     },
 
     /**
-    *  Deprecated - Since version 5.0.0. Use removeListener(eventName) instead
+    *  Deprecated - Since version 0.5.0. Use removeListener(eventName) instead
     *  Remove all event listeners
     */
     removeListeners: function () {
@@ -323,6 +323,7 @@ var CleverTap = {
     },
 
     /**
+     * Deprecated - Since version 0.6.0. Use getCleverTapID(callback) instead
     * Get a unique CleverTap identifier suitable for use with install attribution providers
     * @param {function(err, res)} callback that returns a string res
     */
@@ -331,6 +332,7 @@ var CleverTap = {
     },
 
     /**
+     * Deprecated - Since version 0.6.0. Use getCleverTapID(callback) instead
     * Get the user profile's CleverTap identifier value
     * @param {function(err, res)} callback that returns a string res
     */
@@ -717,6 +719,15 @@ var CleverTap = {
     profileDecrementValueForKey: function(key,value)
     {
         CleverTapReact.decrementValue(key,value);
+    },
+
+    /**
+     * Returns a unique identifier through callback by which CleverTap identifies this user
+     *
+     * @param {function(err, res)} non-null callback to retrieve identifier
+     */
+    getCleverTapID: function (callback) {
+        callWithCallback('getCleverTapID', null, callback);
     },
 
     /**

--- a/index.js
+++ b/index.js
@@ -729,6 +729,38 @@ var CleverTap = {
     },
 
     /**
+     * Suspends display of InApp Notifications.
+     * The InApp Notifications are queued once this method is called
+     * and will be displayed once resumeInAppNotifications() is called.
+     */
+    suspendInAppNotifications: function () {
+        CleverTapReact.suspendInAppNotifications();
+    },
+
+    /**
+     * Suspends the display of InApp Notifications and discards any new InApp Notifications to be shown
+     * after this method is called.
+     * The InApp Notifications will be displayed only once resumeInAppNotifications() is called.
+     */
+    discardInAppNotifications: function () {
+        CleverTapReact.discardInAppNotifications();
+    },
+
+    /**
+     * Resumes display of InApp Notifications.
+     *
+     * If suspendInAppNotifications() was called previously, calling this method will instantly show
+     * all queued InApp Notifications and also resume InApp Notifications on events raised after this
+     * method is called.
+     *
+     * If discardInAppNotifications() was called previously, calling this method will only resume
+     * InApp Notifications on events raised after this method is called.
+     */
+    resumeInAppNotifications: function () {
+        CleverTapReact.resumeInAppNotifications();
+    },
+
+    /**
     * Set the SDK debug level
     * @param {int} 0 = off, 1 = on
     */

--- a/index.js
+++ b/index.js
@@ -698,6 +698,28 @@ var CleverTap = {
     },
 
     /**
+     * This method is used to increment the given value
+     *
+     * @param key   {string} profile property
+     * @param value {Number} can be int,double or float only (NaN,Infinity etc not supported)
+     */
+    profileIncrementValueForKey: function(key,value)
+    {
+        CleverTapReact.incrementValue(key,value);
+    },
+
+    /**
+     * This method is used to decrement the given value
+     *
+     * @param key   {string} profile property
+     * @param value {Number} can be int,double or float only (NaN,Infinity etc not supported)
+     */
+    profileDecrementValueForKey: function(key,value)
+    {
+        CleverTapReact.decrementValue(key,value);
+    },
+
+    /**
     * Set the SDK debug level
     * @param {int} 0 = off, 1 = on
     */

--- a/index.js
+++ b/index.js
@@ -432,6 +432,26 @@ var CleverTap = {
     },
 
     /**
+    * This method is used to increment the given value
+    *
+    * @param value {Number} can be int,double or float only (NaN,Infinity etc not supported)
+    * @param key   {string} profile property
+    */
+    profileIncrementValueForKey: function (value, key) {
+        CleverTapReact.profileIncrementValueForKey(value, key);
+    },
+
+    /**
+     * This method is used to decrement the given value
+     *
+     * @param value {Number} can be int,double or float only (NaN,Infinity etc not supported)
+     * @param key   {string} profile property
+     */
+    profileDecrementValueForKey: function (value, key) {
+        CleverTapReact.profileDecrementValueForKey(value, key);
+    },
+
+    /**
     * Manually track the utm app install referrer
     * @param {string} the utm referrer source
     * @param {string} the utm referrer medium
@@ -697,28 +717,6 @@ var CleverTap = {
     */
     getFeatureFlag: function (name, defaultValue, callback) {
         callWithCallback('getFeatureFlag', [name, defaultValue], callback);
-    },
-
-    /**
-     * This method is used to increment the given value
-     *
-     * @param key   {string} profile property
-     * @param value {Number} can be int,double or float only (NaN,Infinity etc not supported)
-     */
-    profileIncrementValueForKey: function(key,value)
-    {
-        CleverTapReact.incrementValue(key,value);
-    },
-
-    /**
-     * This method is used to decrement the given value
-     *
-     * @param key   {string} profile property
-     * @param value {Number} can be int,double or float only (NaN,Infinity etc not supported)
-     */
-    profileDecrementValueForKey: function(key,value)
-    {
-        CleverTapReact.decrementValue(key,value);
     },
 
     /**

--- a/ios/CleverTapReact/CleverTapReact.m
+++ b/ios/CleverTapReact/CleverTapReact.m
@@ -13,6 +13,7 @@
 #import "CleverTap+DisplayUnit.h"
 #import "CleverTap+FeatureFlags.h"
 #import "CleverTap+ProductConfig.h"
+#import "CleverTap+InAppNotifications.h"
 
 static NSDateFormatter *dateFormatter;
 
@@ -200,6 +201,12 @@ RCT_EXPORT_METHOD(profileGetCleverTapID:(RCTResponseSenderBlock)callback) {
     [self returnResult:result withCallback:callback andError:nil];
 }
 
+RCT_EXPORT_METHOD(getCleverTapID:(RCTResponseSenderBlock)callback) {
+    RCTLogInfo(@"[CleverTap getCleverTapID]");
+    NSString *result = [[CleverTap sharedInstance] profileGetCleverTapID];
+    [self returnResult:result withCallback:callback andError:nil];
+}
+
 RCT_EXPORT_METHOD(onUserLogin:(NSDictionary*)profile) {
     RCTLogInfo(@"[CleverTap onUserLogin: %@]", profile);
     NSDictionary *_profile = [self formatProfile:profile];
@@ -248,6 +255,15 @@ RCT_EXPORT_METHOD(profileRemoveMultiValues:(NSArray<NSString*>*)values forKey:(N
     [[CleverTap sharedInstance] profileRemoveMultiValues:values forKey:key];
 }
 
+RCT_EXPORT_METHOD(profileIncrementValueForKey:(NSNumber* _Nonnull)value forKey:(NSString* _Nonnull)key) {
+    RCTLogInfo(@"[CleverTap profileIncrementValueBy: %@ forKey: %@]", value, key);
+    [[CleverTap sharedInstance] profileIncrementValueBy:value forKey:key];
+}
+
+RCT_EXPORT_METHOD(profileDecrementValueForKey:(NSNumber* _Nonnull)value forKey:(NSString* _Nonnull)key) {
+    RCTLogInfo(@"[CleverTap profileDecrementValueBy: %@ forKey: %@]", value, key);
+    [[CleverTap sharedInstance] profileDecrementValueBy:value forKey:key];
+}
 
 #pragma mark - Session API
 
@@ -684,6 +700,23 @@ RCT_EXPORT_METHOD(getDouble:(NSString*)key callback:(RCTResponseSenderBlock)call
 RCT_EXPORT_METHOD(reset) {
     RCTLogInfo(@"[CleverTap ProductConfig Reset]");
     [[[CleverTap sharedInstance] productConfig] reset];
+}
+
+#pragma mark - InApp Notification Controls
+
+RCT_EXPORT_METHOD(suspendInAppNotifications) {
+    RCTLogInfo(@"[CleverTap suspendInAppNotifications");
+    [[CleverTap sharedInstance] suspendInAppNotifications];
+}
+
+RCT_EXPORT_METHOD(discardInAppNotifications) {
+    RCTLogInfo(@"[CleverTap discardInAppNotifications");
+    [[CleverTap sharedInstance] discardInAppNotifications];
+}
+
+RCT_EXPORT_METHOD(resumeInAppNotifications) {
+    RCTLogInfo(@"[CleverTap resumeInAppNotifications");
+    [[CleverTap sharedInstance] resumeInAppNotifications];
 }
 
 @end

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "clevertap-react-native",
-  "version": "0.5.1",
+  "version": "0.6.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clevertap-react-native",
-  "version": "0.5.2",
+  "version": "0.6.0",
   "description": "CleverTap React Native SDK.",
   "main": "index.js",
   "types": "index.d.ts",


### PR DESCRIPTION
- Adds public methods for suspending/discarding & resuming InApp Notifications
- Adds public methods to increment/decrement values set via User properties
- Deprecates profileGetCleverTapID() and profileGetCleverTapAttributionIdentifier()
- Adds a new public method getCleverTapID() as an alternative to above deprecated methods
- Supports CleverTap iOS SDK v3.10.0