### PR TITLE
[SDK 2847] Pass RN SDK version to core SDK

### DIFF
--- a/Example/package.json
+++ b/Example/package.json
@@ -13,7 +13,7 @@
     "@react-navigation/drawer": "^5.12.5",
     "@react-navigation/native": "^6.0.6",
     "@react-navigation/native-stack": "^6.2.5",
-    "clevertap-react-native": "git+https://github.com/CleverTap/clevertap-react-native#task/SDK-2867/iOS_RN_Killed_State_Push_Callback",
+    "clevertap-react-native": "git+https://github.com/CleverTap/clevertap-react-native#task/SDK-2847/pass_sdk_version",
     "react": "17.0.1",
     "react-native": "0.64.1",
     "react-native-drawer": "^2.5.1",

--- a/clevertap-react-native.podspec
+++ b/clevertap-react-native.podspec
@@ -18,6 +18,6 @@ Pod::Spec.new do |s|
   s.preserve_paths = 'LICENSE.md', 'README.md', 'package.json', 'index.js'
   s.source_files   = 'ios/CleverTapReact/*.{h,m}'
 
-  s.dependency 'CleverTap-iOS-SDK', '4.2.2'
+  s.dependency 'CleverTap-iOS-SDK', '5.0.0'
   s.dependency 'React-Core'
 end

--- a/clevertap-react-native.podspec
+++ b/clevertap-react-native.podspec
@@ -18,6 +18,6 @@ Pod::Spec.new do |s|
   s.preserve_paths = 'LICENSE.md', 'README.md', 'package.json', 'index.js'
   s.source_files   = 'ios/CleverTapReact/*.{h,m}'
 
-  s.dependency 'CleverTap-iOS-SDK', '5.0.0'
+  s.dependency 'CleverTap-iOS-SDK', '5.0.1'
   s.dependency 'React-Core'
 end

--- a/index.js
+++ b/index.js
@@ -6,7 +6,7 @@ const EventEmitter = NativeModules.CleverTapReactEventEmitter ? new NativeEventE
 /**
 * Set the CleverTap React-Native library name with current version
 * @param {string} libName - Library name will be "React-Native"
-* @param {int} libVersion - The updated library version. If current version is 1.0.3 then pass as 10103  
+* @param {int} libVersion - The updated library version. If current version is 1.1.0 then pass as 10100  
 */
 const libName = 'React-Native';
 const libVersion = 10100; 

--- a/index.js
+++ b/index.js
@@ -3,6 +3,15 @@ import { DeviceEventEmitter, NativeEventEmitter, NativeModules } from 'react-nat
 const CleverTapReact = NativeModules.CleverTapReact;
 const EventEmitter = NativeModules.CleverTapReactEventEmitter ? new NativeEventEmitter(NativeModules.CleverTapReactEventEmitter) : DeviceEventEmitter;
 
+/**
+* Set the CleverTap React-Native library name with current version
+* @param {string} libName - Library name will be "React-Native"
+* @param {int} libVersion - The updated library version. If current version is 1.0.3 then pass as 10103  
+*/
+const libName = 'React-Native';
+const libVersion = 10103; 
+CleverTapReact.setLibrary(libName,libVersion);
+
 function defaultCallback(method, err, res) {
     if (err) {
         console.log('CleverTap ' + method + ' default callback error', err);

--- a/index.js
+++ b/index.js
@@ -9,7 +9,7 @@ const EventEmitter = NativeModules.CleverTapReactEventEmitter ? new NativeEventE
 * @param {int} libVersion - The updated library version. If current version is 1.0.3 then pass as 10103  
 */
 const libName = 'React-Native';
-const libVersion = 10103; 
+const libVersion = 10100; 
 CleverTapReact.setLibrary(libName,libVersion);
 
 function defaultCallback(method, err, res) {

--- a/ios/CleverTapReact/CleverTapReact.m
+++ b/ios/CleverTapReact/CleverTapReact.m
@@ -97,6 +97,12 @@ RCT_EXPORT_METHOD(getInitialUrl:(RCTResponseSenderBlock)callback) {
     }
 }
 
+RCT_EXPORT_METHOD(setLibrary:(NSString*)name andVersion:(int)version) {
+    RCTLogInfo(@"[CleverTap setLibrary:%@ andVersion:%d]", name, version);
+    [[self cleverTapInstance] setLibrary:name];
+    [[self cleverTapInstance] setCustomSdkVersion:name version:version];
+}
+
 #pragma mark - Push Notifications
 
 RCT_EXPORT_METHOD(registerForPush) {

--- a/ios/CleverTapReact/CleverTapReactManager.m
+++ b/ios/CleverTapReact/CleverTapReactManager.m
@@ -58,7 +58,6 @@
     [[cleverTapInstance featureFlags] setDelegate:self];
     [[cleverTapInstance productConfig] setDelegate:self];
     [cleverTapInstance setPushPermissionDelegate:self];
-    [cleverTapInstance setLibrary:@"React-Native"];
 }
 
 


### PR DESCRIPTION
- Added a new method `setLibrary:(NSString*)name andVersion:(int)version` to pass library name as well as version to core SDK in iOS.
- Updated index.js to save library name and version after `CleverTapReact` is initialised.