### PR TITLE
task(SDK-3692) - Adds double to map/array if type is long

### DIFF
--- a/android/src/main/java/com/clevertap/react/CleverTapUtils.java
+++ b/android/src/main/java/com/clevertap/react/CleverTapUtils.java
@@ -79,6 +79,8 @@ public class CleverTapUtils {
                     writableMap.putInt(key, (Integer) value);
                 } else if (value instanceof Boolean) {
                     writableMap.putBoolean(key, (Boolean) value);
+                } else if (value instanceof Long) {
+                    writableMap.putDouble(key, ((Long) value).doubleValue());
                 } else if (value instanceof Float || value instanceof Double) {
                     writableMap.putDouble(key, Double.parseDouble(value.toString()));
                 } else if (value instanceof JSONObject) {
@@ -109,6 +111,8 @@ public class CleverTapUtils {
                     writableArray.pushInt((Integer) value);
                 } else if (value instanceof Boolean) {
                     writableArray.pushBoolean((Boolean) value);
+                } else if (value instanceof Long) {
+                    writableArray.pushDouble(((Long) value).doubleValue());
                 } else if (value instanceof Float || value instanceof Double) {
                     writableArray.pushDouble(Double.parseDouble(value.toString()));
                 } else if (value instanceof JSONObject) {


### PR DESCRIPTION
[Android] - Timestamp was received as null as the native sdk passed it as long. Long wasn't handled correctly by the bridge class
JS doesn't have multiple numeric types, whether you'd put a long or double on the native side would be irrelevant for JS and hence long can be put as double