### PR TITLE
Release v2.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,31 @@
 Change Log
 ==========
-
+Version 2.2.0 *(5 April 2024)*
+-------------------------------------------
 **What's new**
+
+* **[Android Platform]**
+  * Supports [CleverTap Android SDK v6.2.0](https://github.com/CleverTap/clevertap-android-sdk/blob/master/docs/CTCORECHANGELOG.md#version-620-april-3-2024).
+
+* **[iOS Platform]**
+  * Supports [CleverTap iOS SDK v6.2.0](https://github.com/CleverTap/clevertap-ios-sdk/releases/tag/6.2.0).
+  * Updates privacy manifests.
+
+**API Changes**
+  * Removes all Xiaomi related public methods as the Xiaomi SDK has been discontinued. Details [here](https://developer.clevertap.com/docs/discontinuation-of-xiaomi-push-service).
+  * Changes the function definition of `setPushToken` to `setPushToken: function (token, type)` i.e it no more accepts `region` as a parameter.
+
+**Bug Fixes**
+* **[Android Platform]**
+  * Extends the push primer callback to notify permission denial when cancel button is clicked on `PromptForSettings` alert dialog.
+  * Fixes a crash due to `NullPointerException` related to `deviceInfo.deviceId`.
+  * Fixes an ANR related to `isMainProcess` check.
+  * Fixes an ANR due to eager initialisation of `CtApi` triggered by DeviceId generation.
+  * Fixes an android build issue related to `package name no found` for apps with ReactNative version less than 0.71.
+
+* **[iOS Platform]**
+  * Fixes a bug where client side in-apps were not discarded when rendering status is set to "discard".
+
 
 Version 2.1.0 *(7 March 2024)*
 -------------------------------------------

--- a/Example/App.js
+++ b/Example/App.js
@@ -1157,7 +1157,6 @@ pushFcmRegistrationId = () => {
     // => https://developer.clevertap.com/docs/android#section-custom-android-push-notifications-handling
     CleverTap.setPushToken('1000test000token000fcm', CleverTap.FCM);
     //CleverTap.setPushToken("111056687894", CleverTap.HMS);//for Huawei push
-    CleverTap.setPushToken('1000test000token000xps', CleverTap.XPS, 'Europe'); //for Xiaomi push
     //CleverTap.setPushToken("111056687894", CleverTap.BPS);//for Baidu push
   }
 };

--- a/Example/android/app/build.gradle
+++ b/Example/android/app/build.gradle
@@ -218,7 +218,7 @@ dependencies {
 
 
     //clevertap
-    implementation 'com.clevertap.android:clevertap-android-sdk:6.1.1'
+    implementation 'com.clevertap.android:clevertap-android-sdk:6.2.0'
     implementation "com.clevertap.android:push-templates:1.2.3"
     implementation project(':clevertap-react-native')
 

--- a/Example/android/app/src/main/java/com/reactnct/MainApplication.java
+++ b/Example/android/app/src/main/java/com/reactnct/MainApplication.java
@@ -70,9 +70,6 @@ public class MainApplication extends CleverTapApplication
     @Override
     public void onCreate() {
         CleverTapAPI.setDebugLevel(LogLevel.VERBOSE);
-        // you can use below two xiaomi related methods from clevertap-react-native 0.9.0 onwards
-        //CleverTapAPI.changeXiaomiCredentials("your xiaomi app id","your xiaomi app key")
-        //CleverTapAPI.enableXiaomiPushOn(XIAOMI_MIUI_DEVICES)
         CleverTapAPI.setNotificationHandler((NotificationHandler) new PushTemplateNotificationHandler());
         CleverTapAPI.getDefaultInstance(getApplicationContext()).enableDeviceNetworkInfoReporting(true);
         registerActivityLifecycleCallbacks(this);

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -20,8 +20,8 @@ android {
     defaultConfig {
         minSdkVersion 19
         targetSdkVersion 34
-        versionCode 210
-        versionName "2.1.0"
+        versionCode 220
+        versionName "2.2.0"
     }
 
     namespace 'com.clevertap.react'
@@ -40,7 +40,7 @@ dependencies {
         maven { url "$rootDir/../node_modules/react-native/android" }
     }
 
-    api 'com.clevertap.android:clevertap-android-sdk:6.1.1'
+    api 'com.clevertap.android:clevertap-android-sdk:6.2.0'
     implementation 'com.android.installreferrer:installreferrer:2.2'
     //compile 'com.android.support:appcompat-v7:28.0.0'
     implementation 'com.facebook.react:react-native:+'

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,10 +1,8 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools">
+<manifest package="com.clevertap.react">
+    <!--
+    Package name has been added to support compatibility for RN versions less than 0.71.
+    This gives warning for RN versions greater than or equal to 0.71 which can be ignored
+    -->
     <application>
-        <service
-            android:name="com.clevertap.android.sdk.pushnotification.amp.CTBackgroundJobService"
-            android:enabled="false"
-            android:exported="false"
-            tools:ignore="MissingClass" />
     </application>
 </manifest>

--- a/android/src/main/java/com/clevertap/react/CleverTapModule.java
+++ b/android/src/main/java/com/clevertap/react/CleverTapModule.java
@@ -1354,27 +1354,6 @@ public class CleverTapModule extends ReactContextBaseJavaModule implements SyncL
     }
 
     @ReactMethod
-    public void setPushTokenAsStringWithRegion(String token, String type, String region) {
-        Logger.v("setPushTokenAsString() called with: token = [" + token + "], type = [" + type + "], region = ["
-                + region + "]");
-
-        CleverTapAPI clevertap = getCleverTapAPI();
-        if (clevertap == null || token == null || type == null || TextUtils.isEmpty(region)) {
-            return;
-        }
-
-        switch (type) {
-            case XPS:
-                clevertap.pushXiaomiRegistrationId(token, region, true);
-                break;
-            default:
-                Log.e(TAG, "Unknown push token type " + type);
-                break;
-        }
-    }
-
-
-    @ReactMethod
     public void showInbox(ReadableMap styleConfig) {
         CTInboxStyleConfig inboxStyleConfig = styleConfigFromReadableMap(styleConfig);
         CleverTapAPI cleverTap = getCleverTapAPI();

--- a/index.d.ts
+++ b/index.d.ts
@@ -72,10 +72,9 @@
   /**
    * Manually set the push token on the CleverTap user profile
    * @param {string} token - the device token
-   * @param {string} type - for Android only, specifying the type of push service token. Values can be CleverTap.FCM for Firebase or CleverTap.XPS for Xiaomi or CleverTap.BPS for Baidu or CleverTap.HPS for Huawei,
-   * @param {string} region - for xps only ,to specify the region
+   * @param {string} type - for Android only, specifying the type of push service token. Values can be CleverTap.FCM for Firebase or CleverTap.BPS for Baidu or CleverTap.HPS for Huawei,
    */
-  export function setPushToken(token: string, type: string,region?:string): void;
+  export function setPushToken(token: string, type: string): void;
 
   /**
    * Create Notification Channel for Android O+
@@ -784,7 +783,6 @@ export function isPushPermissionGranted(callback: CallbackString): void;
   type CallbackString = (err: object, res: string) => void;
 
   export const FCM: string;
-  export const XPS: string;
   export const BPS: string;
   export const HPS: string;
   export const CleverTapProfileDidInitialize: string;

--- a/index.js
+++ b/index.js
@@ -9,7 +9,7 @@ const EventEmitter = NativeModules.CleverTapReactEventEmitter ? new NativeEventE
 * @param {int} libVersion - The updated library version. If current version is 1.1.0 then pass as 10100  
 */
 const libName = 'React-Native';
-const libVersion = 20100; 
+const libVersion = 20200;
 CleverTapReact.setLibrary(libName,libVersion);
 
 function defaultCallback(method, err, res) {
@@ -49,7 +49,6 @@ var CleverTap = {
     CleverTapInAppNotificationDismissed: CleverTapReact.CleverTapInAppNotificationDismissed,
     CleverTapInAppNotificationShowed: CleverTapReact.CleverTapInAppNotificationShowed,
     FCM: CleverTapReact.FCM,
-    XPS: CleverTapReact.XPS,
     BPS: CleverTapReact.BPS,
     HPS: CleverTapReact.HPS,
     CleverTapInboxDidInitialize: CleverTapReact.CleverTapInboxDidInitialize,
@@ -128,17 +127,11 @@ var CleverTap = {
     /**
      * Manually set the push token on the CleverTap user profile
      * @param {string} token - the device token
-     * @param {string} type - for Android only, specifying the type of push service token. Values can be CleverTap.FCM for Firebase or CleverTap.XPS for Xiaomi or CleverTap.BPS for Baidu or CleverTap.HPS for Huawei,
-     * @param {string} region - for xps only ,to specify the region
+     * @param {string} type - for Android only, specifying the type of push service token. Values can be CleverTap.FCM for Firebase or CleverTap.BPS for Baidu or CleverTap.HPS for Huawei,
      */
-    setPushToken: function (token, type, region = "") {
-        console.log(`CleverTap RN | setPushToken | received : token: '${token}' | type:'${type}' | region:'${region}' `)
-        if (type === CleverTap.XPS) {
-            CleverTapReact.setPushTokenAsStringWithRegion(token, type, region);
-        }
-        else {
-            CleverTapReact.setPushTokenAsString(token, type);
-        }
+    setPushToken: function (token, type) {
+        console.log(`CleverTap RN | setPushToken | received : token: '${token}' | type:'${type}' `)
+        CleverTapReact.setPushTokenAsString(token, type);
     },
 
     /**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clevertap-react-native",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "description": "CleverTap React Native SDK.",
   "main": "index.js",
   "types": "index.d.ts",


### PR DESCRIPTION
Version 2.2.0 *(5 April 2024)*
-------------------------------------------
**What's new**

* **[Android Platform]**
  * Supports [CleverTap Android SDK v6.2.0](https://github.com/CleverTap/clevertap-android-sdk/blob/master/docs/CTCORECHANGELOG.md#version-620-april-3-2024).

* **[iOS Platform]**
  * Supports [CleverTap iOS SDK v6.2.0](https://github.com/CleverTap/clevertap-ios-sdk/releases/tag/6.2.0).
  * Updates privacy manifests.

**API Changes**
  * Removes all Xiaomi related public methods as the Xiaomi SDK has been discontinued. Details [here](https://developer.clevertap.com/docs/discontinuation-of-xiaomi-push-service).
  * Changes the function definition of `setPushToken` to `setPushToken: function (token, type)` i.e it no more accepts `region` as a parameter.

**Bug Fixes**
* **[Android Platform]**
  * Extends the push primer callback to notify permission denial when cancel button is clicked on `PromptForSettings` alert dialog.
  * Fixes a crash due to `NullPointerException` related to `deviceInfo.deviceId`.
  * Fixes an ANR related to `isMainProcess` check.
  * Fixes an ANR due to eager initialisation of `CtApi` triggered by DeviceId generation.
  * Fixes an android build issue related to `package name no found` for apps with ReactNative version less than 0.71.

* **[iOS Platform]**
  * Fixes a bug where client side in-apps were not discarded when rendering status is set to "discard".