### PR TITLE
[MC-1588] Save events to be observed when ready

### DIFF
--- a/ios/CleverTapReact.xcodeproj/project.pbxproj
+++ b/ios/CleverTapReact.xcodeproj/project.pbxproj
@@ -17,6 +17,8 @@
 		5266DAB91E4B9C16000008F5 /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5266DAB61E4B9B8C000008F5 /* UIKit.framework */; };
 		5266DABA1E4B9C20000008F5 /* SystemConfiguration.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 52DFC6831E4B990A00EDC368 /* SystemConfiguration.framework */; };
 		5266DADB1E4BB5BD000008F5 /* CleverTapSDK.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5266DAD91E4BB598000008F5 /* CleverTapSDK.framework */; };
+		6B587A032BC02ECD0077493E /* CleverTapReactPendingEvent.m in Sources */ = {isa = PBXBuildFile; fileRef = 6B587A022BC02ECD0077493E /* CleverTapReactPendingEvent.m */; };
+		6B587A042BC02ECD0077493E /* CleverTapReactPendingEvent.h in Headers */ = {isa = PBXBuildFile; fileRef = 6B587A012BC02ECD0077493E /* CleverTapReactPendingEvent.h */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -45,6 +47,8 @@
 		52DFC6831E4B990A00EDC368 /* SystemConfiguration.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SystemConfiguration.framework; path = System/Library/Frameworks/SystemConfiguration.framework; sourceTree = SDKROOT; };
 		52DFC6851E4B991000EDC368 /* CoreTelephony.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreTelephony.framework; path = System/Library/Frameworks/CoreTelephony.framework; sourceTree = SDKROOT; };
 		5D72D2E81C16249000E22EC1 /* libCleverTapReact.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libCleverTapReact.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		6B587A012BC02ECD0077493E /* CleverTapReactPendingEvent.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CleverTapReactPendingEvent.h; sourceTree = "<group>"; };
+		6B587A022BC02ECD0077493E /* CleverTapReactPendingEvent.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = CleverTapReactPendingEvent.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -71,6 +75,8 @@
 				52344FBC1E4CE7F000661762 /* CleverTapReactManager.m */,
 				52344FDE1E4D0F3700661762 /* CleverTapReactEventEmitter.h */,
 				52344FDF1E4D0F3700661762 /* CleverTapReactEventEmitter.m */,
+				6B587A012BC02ECD0077493E /* CleverTapReactPendingEvent.h */,
+				6B587A022BC02ECD0077493E /* CleverTapReactPendingEvent.m */,
 			);
 			path = CleverTapReact;
 			sourceTree = "<group>";
@@ -111,6 +117,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				52344FC21E4CEC3200661762 /* CleverTapReactManager.h in Headers */,
+				6B587A042BC02ECD0077493E /* CleverTapReactPendingEvent.h in Headers */,
 				52344FE01E4D0F3700661762 /* CleverTapReactEventEmitter.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -176,6 +183,7 @@
 				52344FBF1E4CE7F000661762 /* CleverTapReactManager.m in Sources */,
 				52344FE11E4D0F3700661762 /* CleverTapReactEventEmitter.m in Sources */,
 				52344FBE1E4CE7F000661762 /* CleverTapReact.m in Sources */,
+				6B587A032BC02ECD0077493E /* CleverTapReactPendingEvent.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/ios/CleverTapReact/CleverTapReactEventEmitter.h
+++ b/ios/CleverTapReact/CleverTapReactEventEmitter.h
@@ -2,4 +2,6 @@
 
 @interface CleverTapReactEventEmitter : RCTEventEmitter
 
++ (void)sendEventOnObserving:(NSString *)name body:(id)body;
+
 @end

--- a/ios/CleverTapReact/CleverTapReactManager.m
+++ b/ios/CleverTapReact/CleverTapReactManager.m
@@ -17,7 +17,7 @@
 #import "CleverTapPushNotificationDelegate.h"
 #import "CleverTapInAppNotificationDelegate.h"
 #import "CleverTap+PushPermission.h"
-
+#import "CleverTapReactEventEmitter.h"
 
 @interface CleverTapReactManager() <CleverTapSyncDelegate, CleverTapInAppNotificationDelegate, CleverTapDisplayUnitDelegate,  CleverTapFeatureFlagsDelegate, CleverTapProductConfigDelegate, CleverTapPushNotificationDelegate, CleverTapPushPermissionDelegate> {
 }
@@ -75,7 +75,7 @@
 #pragma mark - Private
 
 - (void)postNotificationWithName:(NSString *)name andBody:(NSDictionary *)body {
-    [[NSNotificationCenter defaultCenter] postNotificationName:name object:nil userInfo:body];
+    [CleverTapReactEventEmitter sendEventOnObserving:name body:body];
 }
 
 

--- a/ios/CleverTapReact/CleverTapReactPendingEvent.h
+++ b/ios/CleverTapReact/CleverTapReactPendingEvent.h
@@ -1,0 +1,14 @@
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface CleverTapReactPendingEvent : NSObject
+
+@property (nonatomic, strong) NSString *name;
+@property (nonatomic, strong) id body;
+
+- (instancetype)initWithName:(NSString *)name body:(id)body;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/ios/CleverTapReact/CleverTapReactPendingEvent.m
+++ b/ios/CleverTapReact/CleverTapReactPendingEvent.m
@@ -1,0 +1,14 @@
+#import "CleverTapReactPendingEvent.h"
+
+@implementation CleverTapReactPendingEvent
+
+- (instancetype)initWithName:(NSString *)name body:(id)body {
+    self = [super init];
+    if (self) {
+        _name = name;
+        _body = body;
+    }
+    return self;
+}
+
+@end


### PR DESCRIPTION
## Background
If an event is posted before `CleverTapReactEventEmitter` starts observing, the event will be lost.
For example, if an event is sent on `AppDelegate didFinishLaunchingWithOptions` it will not be received in the JS listener.
This currently happens with the `CleverTapProfileDidInitialize` which is also sent/posted before the events are observed.

The default React Native error, that an event is posted without having any listeners, will not be logged since the `CleverTapReactEventEmitter` logic abstracts and hides it. The notification will be posted but no observer will be added since `CleverTapReactEventEmitter` `startObserving` will not be called yet. Hence the `sendEventWithName` method will not be called and the error will be not be logged.

## Implementation
Save all events posted before `CleverTapReactEventEmitter` `startObserving`. 
Use  `[CleverTapReactEventEmitter sendEventOnObserving:event body:body];` to send the events.

## Testing
Manual

## Backwards compatible
Yes