### PR TITLE
task(SDK-3770) - Adds support for iOS SDK v6.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,15 @@ Version 2.2.1 *(12 April 2024)*
 * **[Android Platform]**
   * Supports [CleverTap Android SDK v6.2.1](https://github.com/CleverTap/clevertap-android-sdk/blob/master/docs/CTCORECHANGELOG.md#version-620-april-3-2024).
 
+* **[iOS Platform]**
+  * Supports [CleverTap iOS SDK v6.2.1](https://github.com/CleverTap/clevertap-ios-sdk/blob/master/CHANGELOG.md#version-621-april-12-2024).
+
 **Bug Fixes**
 * **[Android Platform]**
   * Fixes a crash due to `IllegalArgumentException` caused by allowedPushType `XPS` enum.
+
+* **[iOS Platform]**
+  * Fixes a build error related to privacy manifests when statically linking the SDK using Cocoapods.
 
 
 Version 2.2.0 *(5 April 2024)*

--- a/clevertap-react-native.podspec
+++ b/clevertap-react-native.podspec
@@ -18,6 +18,6 @@ Pod::Spec.new do |s|
   s.preserve_paths = 'LICENSE.md', 'README.md', 'package.json', 'index.js'
   s.source_files   = 'ios/CleverTapReact/*.{h,m}'
 
-  s.dependency 'CleverTap-iOS-SDK', '6.2.0'
+  s.dependency 'CleverTap-iOS-SDK', '6.2.1'
   s.dependency 'React-Core'
 end


### PR DESCRIPTION
- Supports iOS SDK v6.2.1.
- Fixes a build error related to privacy manifests when statically linking the SDK using Cocoapods.