### PR TITLE
Custom templates example UI

### DIFF
--- a/Example/App.js
+++ b/Example/App.js
@@ -2,6 +2,7 @@
 import React, {Component} from 'react';
 import {NavigationContainer} from '@react-navigation/native';
 import {createNativeStackNavigator} from '@react-navigation/native-stack';
+import CustomTemplate from './CustomTemplate';
 
 import {
   Alert,
@@ -910,6 +911,7 @@ export default class App extends Component {
           <TouchableOpacity style={styles.button}>
             <Text style={styles.button_Text}>CleverTap Example</Text>
           </TouchableOpacity>
+          <CustomTemplate></CustomTemplate>
           {this.state.AccordionData.map((item, key) => (
             <Expandable_ListView
               key={item.category_Name}
@@ -995,7 +997,7 @@ pushevent = () => {
   // CleverTap.recordEvent('testEvent');
   // CleverTap.recordEvent('Send Basic Push');
   // CleverTap.recordEvent('testEventWithProps', {start: new Date(), foo: 'bar'});
-  CleverTap.recordEvent('template');
+  CleverTap.recordEvent('pushEvent');
 };
 
 pushChargedEvent = () => {
@@ -1494,26 +1496,6 @@ function addCleverTapAPIListeners(fromClick) {
   );
   if (fromClick) {
     alert('Listeners added successfully');
-  }
-  CleverTap.addListener(CleverTap.CleverTapCustomTemplatePresent, templateName => {
-    getTemplateValuesString(templateName).then((str)=> {
-       alert(str);
-    })
-  })
-}
-
-async function getTemplateValuesString(templateName) {
-  try {
-    var var1 = await CleverTap.customTemplateGetBooleanArg(templateName, "var1");
-    var var2 = await CleverTap.customTemplateGetStringArg(templateName, "var2");
-    var var3 = await CleverTap.customTemplateGetNumberArg(templateName, "folder1.var3");
-    var var4 = await CleverTap.customTemplateGetFileArg(templateName, "folder1.var4");
-    var folder1 = await CleverTap.customTemplateGetObjectArg(templateName, "folder1");
-    await CleverTap.customTemplateSetPresented(templateName);
-    await CleverTap.customTemplateSetDismissed(templateName);
-    return `Template Presented ${templateName}\nvar1=${var1}\nvar2=${var2}\nfolder1.var3=${var3}\nfolder1.var4=${var4}\nfolder1=${JSON.stringify(folder1)}`;
-  } catch (e) {
-    return e.toString();
   }
 }
 

--- a/Example/CustomTemplate.js
+++ b/Example/CustomTemplate.js
@@ -49,7 +49,7 @@ const CustomTemplate = () => {
     }, []);
 
     const presentInAppModal = (name, isFunction) => {
-        getTemplateValuesString(name).then((str) => {
+        CleverTap.customTemplateContextToString(name).then((str) => {
             let description = `Arguments for "${name}":${str}`;
             setModalState(prevState => {
                 // If the in-app template modal is already visible, this means `presentInAppModal`
@@ -78,58 +78,6 @@ triggered by action from template "${prevState.templateName}".`);
                 }
             });
         });
-    };
-
-    const getTemplateValuesString = async (templateName) => {
-        switch (templateName) {
-            case "Example template":
-                try {
-                    var bool = await CleverTap.customTemplateGetBooleanArg(templateName, "bool");
-                    var string = await CleverTap.customTemplateGetStringArg(templateName, "string");
-                    var mapInt = await CleverTap.customTemplateGetNumberArg(templateName, "map.int");
-                    var mapString = await CleverTap.customTemplateGetStringArg(templateName, "map.string");
-                    var map = await CleverTap.customTemplateGetObjectArg(templateName, "map");
-                    var file = await CleverTap.customTemplateGetFileArg(templateName, "file");
-                    return `
-bool=${bool}
-string=${string}
-map.int=${mapInt}
-map.string=${mapString}
-map=${JSON.stringify(map)}
-file=${file}`;
-                } catch (e) {
-                    return e.toString();
-                }
-
-            case "Example function":
-                try {
-                    var double = await CleverTap.customTemplateGetNumberArg(templateName, "double");
-                    var string = await CleverTap.customTemplateGetStringArg(templateName, "string");
-                    var file = await CleverTap.customTemplateGetFileArg(templateName, "file");
-                    return `
-double=${double}
-string=${string}
-file=${file}`;
-                } catch (e) {
-                    return e.toString();
-                }
-
-            case "Example visual function":
-                try {
-                    var color = await CleverTap.customTemplateGetStringArg(templateName, "color");
-                    var enabled = await CleverTap.customTemplateGetBooleanArg(templateName, "enabled");
-                    var image = await CleverTap.customTemplateGetFileArg(templateName, "image");
-                    return `
-color=${color}
-enabled=${enabled}
-image=${image}`;
-                } catch (e) {
-                    return e.toString();
-                }
-
-            default:
-                return "Template not found"
-        }
     };
 
     const handleCancel = () => {

--- a/Example/CustomTemplate.js
+++ b/Example/CustomTemplate.js
@@ -1,0 +1,227 @@
+import React, { useState, useEffect } from 'react';
+import { View, Modal, Text, TouchableOpacity, StyleSheet } from 'react-native';
+import InAppMessagePopup from './InAppMessagePopup';
+import { WebView } from 'react-native-webview';
+
+const CleverTap = require('clevertap-react-native');
+
+const CustomTemplate = () => {
+    const [isModalVisible, setIsModalVisible] = useState(false);
+    const [templateName, setTemplateName] = useState('');
+    const [description, setDescription] = useState('');
+    const [isFunction, setIsFunction] = useState(false);
+    const [filePath, setFilePath] = useState('');
+    const [showWebView, setShowWebView] = useState(false);
+    const [templateNameVisual, setTemplateNameVisual] = useState('');
+
+    useEffect(() => {
+        CleverTap.addListener(CleverTap.CleverTapCustomTemplatePresent, templateName => {
+            setIsFunction(false);
+            presentInAppModal(templateName);
+        });
+
+        CleverTap.addListener(CleverTap.CleverTapCustomTemplateClose, templateName => {
+            CleverTap.customTemplateSetDismissed(templateName);
+            setIsModalVisible(true);
+        });
+
+        CleverTap.addListener(CleverTap.CleverTapCustomFunctionPresent, templateName => {
+            setIsFunction(true);
+            presentInAppModal(templateName);
+        });
+
+        return () => {
+            CleverTap.removeListener(CleverTap.CleverTapCustomTemplatePresent);
+            CleverTap.removeListener(CleverTap.CleverTapCustomTemplateClose);
+            CleverTap.removeListener(CleverTap.CleverTapCustomFunctionPresent);
+        };
+    }, []);
+
+    const presentInAppModal = (name) => {
+        if (isModalVisible) {
+            // Showing a custom function with isVisual:false
+            setTemplateNameVisual(templateName);
+        }
+        getTemplateValuesString(name).then((str) => {
+            setDescription(str);
+            setTemplateName(name);
+            setIsModalVisible(true);
+        });
+    };
+
+    const getTemplateValuesString = async (templateName) => {
+        switch (templateName) {
+            case "Example template":
+                try {
+                    var bool = await CleverTap.customTemplateGetBooleanArg(templateName, "bool");
+                    var string = await CleverTap.customTemplateGetStringArg(templateName, "string");
+                    var mapInt = await CleverTap.customTemplateGetNumberArg(templateName, "map.int");
+                    var mapString = await CleverTap.customTemplateGetStringArg(templateName, "map.string");
+                    var map = await CleverTap.customTemplateGetObjectArg(templateName, "map");
+                    var file = await CleverTap.customTemplateGetFileArg(templateName, "file");
+                    return `Arguments for ${templateName}:
+bool=${bool}
+string=${string}
+map.int=${mapInt}
+map.string=${mapString}
+map=${JSON.stringify(map)}
+file=${file}`;
+                } catch (e) {
+                    return e.toString();
+                }
+
+            case "Example function":
+                try {
+                    var double = await CleverTap.customTemplateGetNumberArg(templateName, "double");
+                    var string = await CleverTap.customTemplateGetStringArg(templateName, "string");
+                    var file = await CleverTap.customTemplateGetFileArg(templateName, "file");
+                    return `Arguments for ${templateName}:
+double=${double}
+string=${string}
+file=${file}`;
+                } catch (e) {
+                    return e.toString();
+                }
+
+            case "Example visual function":
+                try {
+                    var color = await CleverTap.customTemplateGetStringArg(templateName, "color");
+                    var enabled = await CleverTap.customTemplateGetBooleanArg(templateName, "enabled");
+                    var image = await CleverTap.customTemplateGetFileArg(templateName, "image");
+                    return `Arguments for ${templateName}:
+color=${double}
+string=${string}
+image=${image}`;
+                } catch (e) {
+                    return e.toString();
+                }
+
+            default:
+                return "Template not found"
+        }
+    };
+
+    const handleCancel = () => {
+        CleverTap.customTemplateSetDismissed(templateName);
+        setIsModalVisible(false);
+
+        // If a function with isVisual:false was presented,
+        // show the template modal, so it can be dismissed
+        if (templateNameVisual && templateNameVisual != '') {
+            presentInAppModal(templateNameVisual);
+            setTemplateNameVisual('');
+        }
+    };
+
+    const handleConfirm = () => {
+        CleverTap.customTemplateSetPresented(templateName);
+        setIsModalVisible(false);
+    };
+
+    const handleTriggerAction = (actionName) => {
+        console.log('trigger action:', actionName);
+        CleverTap.customTemplateRunAction(templateName, actionName);
+    };
+
+    const handleOpenFile = (fileName) => {
+        console.log('open file name:', fileName);
+        CleverTap.customTemplateGetFileArg(templateName, fileName).then((filePath) => {
+            console.log('open file path:', filePath);
+            setFilePath(filePath);
+
+            setIsModalVisible(false);
+            setShowWebView(true);
+        });
+    };
+
+    const closeWebView = () => {
+        setShowWebView(false);
+        setFilePath('');
+        setIsModalVisible(true);
+    };
+
+    return (
+        <View style={{ flex: 1, justifyContent: 'center', alignItems: 'center' }}>
+            {/* <Button title="Show Modal" onPress={() => setIsModalVisible(true)} /> */}
+
+            <InAppMessagePopup
+                visible={isModalVisible}
+                title={templateName}
+                description={description}
+                isFunction={isFunction}
+                onCancel={handleCancel}
+                onConfirm={handleConfirm}
+                onTriggerAction={handleTriggerAction}
+                onFileOpen={handleOpenFile}
+            >
+            </InAppMessagePopup>
+
+            {/* {showWebView && (
+                <View style={{ height: 400, width: '90%', marginTop: 20 }}>
+                    <WebView
+                        source={{ uri: filePath }}
+                        style={{ flex: 1 }}
+                        originWhitelist={['*']}
+                        allowFileAccessFromFileURLs={true}
+                    />
+                </View>
+            )} */}
+
+            <Modal
+                visible={showWebView}
+                transparent={true}
+                animationType="slide"
+                onRequestClose={closeWebView}
+            >
+                <View style={styles.webViewContainer}>
+                    <View style={styles.webViewHeader}>
+                        <TouchableOpacity onPress={closeWebView} style={styles.closeButton}>
+                            <Text style={styles.closeButtonText}>X</Text>
+                        </TouchableOpacity>
+                    </View>
+
+                    <View style={styles.webViewWrapper}>
+                        <WebView
+                            source={{ uri: filePath }}
+                            style={{ flex: 1, backgroundColor: 'transparent' }}
+                            originWhitelist={['*']}
+                            allowFileAccessFromFileURLs={true}
+                        />
+                    </View>
+                </View>
+            </Modal>
+        </View>
+    );
+};
+
+const styles = StyleSheet.create({
+    webViewContainer: {
+        flex: 1,
+        backgroundColor: 'rgba(0, 0, 0, 0.8)',
+        justifyContent: 'center',
+        alignItems: 'center'
+    },
+    webViewWrapper: {
+        width: '90%',
+        height: '90%',
+        paddingTop: 10
+    },
+    webViewHeader: {
+        position: 'absolute',
+        top: 40,
+        right: 20,
+        zIndex: 1,
+    },
+    closeButton: {
+        backgroundColor: '#fff',
+        borderRadius: 15,
+        padding: 10,
+    },
+    closeButtonText: {
+        fontSize: 18,
+        fontWeight: 'bold',
+        color: 'red',
+    },
+});
+
+export default CustomTemplate;

--- a/Example/CustomTemplate.js
+++ b/Example/CustomTemplate.js
@@ -25,6 +25,7 @@ const CustomTemplate = () => {
 
     const [filePath, setFilePath] = useState('');
     const [showWebView, setShowWebView] = useState(false);
+    const [webViewLoaded, setWebViewLoaded] = useState(false);
 
     useEffect(() => {
         CleverTap.addListener(CleverTap.CleverTapCustomTemplatePresent, templateName => {
@@ -121,7 +122,7 @@ triggered by action from template "${prevState.templateName}".`);
         console.log('Open file argument named:', name);
         CleverTap.customTemplateGetFileArg(getCurrentName(), name).then((filePath) => {
             console.log('Open file path:', filePath);
-            setFilePath(filePath);
+            setFilePath(filePath || '');
 
             setModalState(prevState => ({
                 ...prevState,
@@ -135,12 +136,18 @@ triggered by action from template "${prevState.templateName}".`);
 
     const closeWebView = () => {
         setShowWebView(false);
+        setWebViewLoaded(false);
         setFilePath('');
         setModalState(prevState => ({
             ...prevState,
             isTemplateVisible: prevState.webViewCaller == WebViewCaller.INAPP_POPUP,
             isNonVisualFunctionVisible: prevState.webViewCaller == WebViewCaller.FUNCTION_POPUP,
         }));
+    };
+
+    const updateSource = () => {
+        console.log('updated');
+        setWebViewLoaded(true);
     };
 
     return (
@@ -181,10 +188,13 @@ triggered by action from template "${prevState.templateName}".`);
 
                     <View style={styles.webViewWrapper}>
                         <WebView
-                            source={{ uri: filePath }}
+                            source={webViewLoaded ? { uri: filePath } : { uri: '' }}
                             style={styles.webView}
                             originWhitelist={['*']}
                             allowFileAccessFromFileURLs={true}
+                            allowFileAccess={true}
+                            allowUniversalAccessFromFileURLs={true}
+                            onLoad={updateSource}
                         />
                     </View>
                 </View>

--- a/Example/FunctionPopup.js
+++ b/Example/FunctionPopup.js
@@ -1,9 +1,8 @@
 import React, { useState } from 'react';
 import { Modal, View, Text, TextInput, TouchableOpacity, StyleSheet } from 'react-native';
 
-const InAppMessagePopup = ({ visible, title, description, isFunction,
-   onCancel, onConfirm, onTriggerAction, onFileOpen }) => {
-  const [actionName, setActionName] = useState('');
+const FunctionPopup = ({ visible, title, description,
+   onClose, onFileOpen }) => {
   const [fileName, setFileName] = useState('');
 
   return (
@@ -26,31 +25,12 @@ const InAppMessagePopup = ({ visible, title, description, isFunction,
             onChangeText={setFileName}
           />
           <TouchableOpacity style={styles.submitButton} onPress={() => onFileOpen(fileName)}>
-            <Text style={styles.submitButtonText}>Open File</Text>
+            <Text style={styles.buttonText}>Open File</Text>
           </TouchableOpacity>
 
-          {!isFunction &&
-            <View style={styles.inputContainer}>
-              <TextInput
-                style={styles.input}
-                placeholder="Action Arg name"
-                placeholderTextColor="grey"
-                autoCapitalize="none"
-                value={actionName}
-                onChangeText={setActionName}
-              />
-              <TouchableOpacity style={styles.submitButton} onPress={() => onTriggerAction(actionName)}>
-                <Text style={styles.submitButtonText}>Trigger Action</Text>
-              </TouchableOpacity>
-            </View>
-          }
-
           <View style={styles.buttonContainer}>
-            <TouchableOpacity style={styles.cancelButton} onPress={onCancel}>
-              <Text style={styles.buttonText}>Cancel</Text>
-            </TouchableOpacity>
-            <TouchableOpacity style={styles.confirmButton} onPress={onConfirm}>
-              <Text style={styles.buttonText}>Confirm</Text>
+            <TouchableOpacity style={styles.cancelButton} onPress={onClose}>
+              <Text style={styles.buttonText}>Close</Text>
             </TouchableOpacity>
           </View>
         </View>
@@ -103,10 +83,6 @@ const styles = StyleSheet.create({
     borderRadius: 5,
     marginBottom: 20,
   },
-  submitButtonText: {
-    color: 'white',
-    textAlign: 'center',
-  },
   buttonContainer: {
     flexDirection: 'row',
     justifyContent: 'space-between',
@@ -117,14 +93,6 @@ const styles = StyleSheet.create({
     padding: 10,
     backgroundColor: '#f44336',
     borderRadius: 5,
-    marginRight: 10,
-  },
-  confirmButton: {
-    flex: 1,
-    padding: 10,
-    backgroundColor: '#4CAF50',
-    borderRadius: 5,
-    marginLeft: 10,
   },
   buttonText: {
     color: 'white',
@@ -132,4 +100,4 @@ const styles = StyleSheet.create({
   },
 });
 
-export default InAppMessagePopup;
+export default FunctionPopup;

--- a/Example/FunctionPopup.js
+++ b/Example/FunctionPopup.js
@@ -1,6 +1,8 @@
 import React, { useState } from 'react';
 import { Modal, View, Text, TextInput, TouchableOpacity, StyleSheet } from 'react-native';
 
+const styles = require('./styles');
+
 const FunctionPopup = ({ visible, title, description,
    onClose, onFileOpen }) => {
   const [fileName, setFileName] = useState('');
@@ -39,65 +41,9 @@ const FunctionPopup = ({ visible, title, description,
   );
 };
 
-const styles = StyleSheet.create({
-  modalBackground: {
-    flex: 1,
-    justifyContent: 'center',
-    alignItems: 'center',
-    backgroundColor: 'rgba(0, 0, 0, 0.5)',
-  },
-  popupContainer: {
-    width: '80%',
-    padding: 20,
-    backgroundColor: 'white',
-    borderRadius: 10,
-    alignItems: 'center',
-  },
-  title: {
-    fontSize: 18,
-    fontWeight: 'bold',
-    marginBottom: 10,
-  },
-  description: {
-    fontSize: 14,
-    color: 'gray',
-    marginBottom: 20,
-    textAlign: 'center',
-  },
-  inputContainer: {
-    width: '100%'
-  },
-  input: {
-    width: '100%',
-    height: 40,
-    borderColor: 'gray',
-    borderWidth: 1,
-    borderRadius: 5,
-    paddingHorizontal: 10,
-    marginBottom: 20
-  },
-  submitButton: {
-    width: '100%',
-    padding: 10,
-    backgroundColor: '#4CAF50',
-    borderRadius: 5,
-    marginBottom: 20,
-  },
-  buttonContainer: {
-    flexDirection: 'row',
-    justifyContent: 'space-between',
-    width: '100%',
-  },
-  cancelButton: {
-    flex: 1,
-    padding: 10,
-    backgroundColor: '#f44336',
-    borderRadius: 5,
-  },
-  buttonText: {
-    color: 'white',
-    textAlign: 'center',
-  },
-});
+styles.cancelButton = {
+    ...styles.cancelButton,
+    marginRight: 'initial',
+}
 
 export default FunctionPopup;

--- a/Example/InAppMessagePopup.js
+++ b/Example/InAppMessagePopup.js
@@ -1,6 +1,8 @@
 import React, { useState } from 'react';
 import { Modal, View, Text, TextInput, TouchableOpacity, StyleSheet } from 'react-native';
 
+const styles = require('./styles');
+
 const InAppMessagePopup = ({ visible, title, description, isFunction,
    onCancel, onConfirm, onTriggerAction, onFileOpen }) => {
   const [actionName, setActionName] = useState('');
@@ -26,7 +28,7 @@ const InAppMessagePopup = ({ visible, title, description, isFunction,
             onChangeText={setFileName}
           />
           <TouchableOpacity style={styles.submitButton} onPress={() => onFileOpen(fileName)}>
-            <Text style={styles.submitButtonText}>Open File</Text>
+            <Text style={styles.buttonText}>Open File</Text>
           </TouchableOpacity>
 
           {!isFunction &&
@@ -40,7 +42,7 @@ const InAppMessagePopup = ({ visible, title, description, isFunction,
                 onChangeText={setActionName}
               />
               <TouchableOpacity style={styles.submitButton} onPress={() => onTriggerAction(actionName)}>
-                <Text style={styles.submitButtonText}>Trigger Action</Text>
+                <Text style={styles.buttonText}>Trigger Action</Text>
               </TouchableOpacity>
             </View>
           }
@@ -58,78 +60,5 @@ const InAppMessagePopup = ({ visible, title, description, isFunction,
     </Modal>
   );
 };
-
-const styles = StyleSheet.create({
-  modalBackground: {
-    flex: 1,
-    justifyContent: 'center',
-    alignItems: 'center',
-    backgroundColor: 'rgba(0, 0, 0, 0.5)',
-  },
-  popupContainer: {
-    width: '80%',
-    padding: 20,
-    backgroundColor: 'white',
-    borderRadius: 10,
-    alignItems: 'center',
-  },
-  title: {
-    fontSize: 18,
-    fontWeight: 'bold',
-    marginBottom: 10,
-  },
-  description: {
-    fontSize: 14,
-    color: 'gray',
-    marginBottom: 20,
-    textAlign: 'center',
-  },
-  inputContainer: {
-    width: '100%'
-  },
-  input: {
-    width: '100%',
-    height: 40,
-    borderColor: 'gray',
-    borderWidth: 1,
-    borderRadius: 5,
-    paddingHorizontal: 10,
-    marginBottom: 20
-  },
-  submitButton: {
-    width: '100%',
-    padding: 10,
-    backgroundColor: '#4CAF50',
-    borderRadius: 5,
-    marginBottom: 20,
-  },
-  submitButtonText: {
-    color: 'white',
-    textAlign: 'center',
-  },
-  buttonContainer: {
-    flexDirection: 'row',
-    justifyContent: 'space-between',
-    width: '100%',
-  },
-  cancelButton: {
-    flex: 1,
-    padding: 10,
-    backgroundColor: '#f44336',
-    borderRadius: 5,
-    marginRight: 10,
-  },
-  confirmButton: {
-    flex: 1,
-    padding: 10,
-    backgroundColor: '#4CAF50',
-    borderRadius: 5,
-    marginLeft: 10,
-  },
-  buttonText: {
-    color: 'white',
-    textAlign: 'center',
-  },
-});
 
 export default InAppMessagePopup;

--- a/Example/InAppMessagePopup.js
+++ b/Example/InAppMessagePopup.js
@@ -1,0 +1,135 @@
+import React, { useState } from 'react';
+import { Modal, View, Text, TextInput, TouchableOpacity, StyleSheet } from 'react-native';
+
+const InAppMessagePopup = ({ visible, title, description, isFunction,
+   onCancel, onConfirm, onTriggerAction, onFileOpen }) => {
+  const [actionName, setActionName] = useState('');
+  const [fileName, setFileName] = useState('');
+
+  return (
+    <Modal
+      visible={visible}
+      transparent={true}
+      animationType="fade"
+    >
+      <View style={styles.modalBackground}>
+        <View style={styles.popupContainer}>
+          <Text style={styles.title}>{title}</Text>
+          <Text style={styles.description}>{description}.</Text>
+
+          <TextInput
+            style={styles.input}
+            placeholder="FileArg name"
+            placeholderTextColor="grey"
+            autoCapitalize='none'
+            value={fileName}
+            onChangeText={setFileName}
+          />
+          <TouchableOpacity style={styles.submitButton} onPress={() => onFileOpen(fileName)}>
+            <Text style={styles.submitButtonText}>Open File</Text>
+          </TouchableOpacity>
+
+          {!isFunction &&
+            <View style={styles.inputContainer}>
+              <TextInput
+                style={styles.input}
+                placeholder="Action name"
+                placeholderTextColor="grey"
+                autoCapitalize='none'
+                value={actionName}
+                onChangeText={setActionName}
+              />
+              <TouchableOpacity style={styles.submitButton} onPress={() => onTriggerAction(actionName)}>
+                <Text style={styles.submitButtonText}>Trigger Action</Text>
+              </TouchableOpacity>
+            </View>
+          }
+
+          <View style={styles.buttonContainer}>
+            <TouchableOpacity style={styles.cancelButton} onPress={onCancel}>
+              <Text style={styles.buttonText}>Cancel</Text>
+            </TouchableOpacity>
+            <TouchableOpacity style={styles.confirmButton} onPress={onConfirm}>
+              <Text style={styles.buttonText}>Confirm</Text>
+            </TouchableOpacity>
+          </View>
+        </View>
+      </View>
+    </Modal>
+  );
+};
+
+const styles = StyleSheet.create({
+  modalBackground: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+    backgroundColor: 'rgba(0, 0, 0, 0.5)',
+  },
+  popupContainer: {
+    width: '80%',
+    padding: 20,
+    backgroundColor: 'white',
+    borderRadius: 10,
+    alignItems: 'center',
+  },
+  title: {
+    fontSize: 18,
+    fontWeight: 'bold',
+    marginBottom: 10,
+  },
+  description: {
+    fontSize: 14,
+    color: 'gray',
+    marginBottom: 20,
+    textAlign: 'center',
+  },
+  inputContainer: {
+    width: '100%'
+  },
+  input: {
+    width: '100%',
+    height: 40,
+    borderColor: 'gray',
+    borderWidth: 1,
+    borderRadius: 5,
+    paddingHorizontal: 10,
+    marginBottom: 20
+  },
+  submitButton: {
+    width: '100%',
+    padding: 10,
+    backgroundColor: '#4CAF50',
+    borderRadius: 5,
+    marginBottom: 20,
+  },
+  submitButtonText: {
+    color: 'white',
+    textAlign: 'center',
+  },
+  buttonContainer: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    width: '100%',
+  },
+  cancelButton: {
+    flex: 1,
+    padding: 10,
+    backgroundColor: '#f44336',
+    borderRadius: 5,
+    marginRight: 10,
+  },
+  confirmButton: {
+    flex: 1,
+    padding: 10,
+    backgroundColor: '#4CAF50',
+    borderRadius: 5,
+    marginLeft: 10,
+  },
+  buttonText: {
+    color: 'white',
+    textAlign: 'center',
+  },
+});
+
+export default InAppMessagePopup;

--- a/Example/InAppMessagePopup.js
+++ b/Example/InAppMessagePopup.js
@@ -49,10 +49,10 @@ const InAppMessagePopup = ({ visible, title, description, isFunction,
 
           <View style={styles.buttonContainer}>
             <TouchableOpacity style={styles.cancelButton} onPress={onCancel}>
-              <Text style={styles.buttonText}>Cancel</Text>
+              <Text style={styles.buttonText}>Dismiss</Text>
             </TouchableOpacity>
             <TouchableOpacity style={styles.confirmButton} onPress={onConfirm}>
-              <Text style={styles.buttonText}>Confirm</Text>
+              <Text style={styles.buttonText}>Set Presented</Text>
             </TouchableOpacity>
           </View>
         </View>

--- a/Example/assets/templates.json
+++ b/Example/assets/templates.json
@@ -1,43 +1,68 @@
 {
-    "template-lina": {
-      "type": "template",
-      "arguments": {
-        "var1": {
-          "type": "boolean",
-          "value": false
-        },
-        "var2": {
-          "type": "string",
-          "value": "Default"
-        },
-        "folder1": {
-          "type": "object",
-          "value": {
-            "var3": {
-              "type": "number",
-              "value": 0
-            }
-          }
-        },
-        "folder1.var4": {
-          "type": "file"
-        },
-        "map": {
-          "type": "object",
-          "value": {
-            "int": {
-              "type": "number",
-              "value": 0
+    "Example template": {
+        "type": "template",
+        "arguments": {
+            "bool": {
+                "type": "boolean",
+                "value": false
             },
             "string": {
-              "type": "string",
-              "value": "Default"
+                "type": "string",
+                "value": "Default"
+            },
+            "map": {
+                "type": "object",
+                "value": {
+                    "int": {
+                        "type": "number",
+                        "value": 0
+                    },
+                    "string": {
+                        "type": "string",
+                        "value": "Default"
+                    }
+                }
+            },
+            "action": {
+                "type": "action"
+            },
+            "file": {
+                "type": "file"
             }
-          }
-        },
-        "action": {
-          "type": "action"
         }
-      }
+    },
+    "Example function": {
+        "type": "function",
+        "isVisual": false,
+        "arguments": {
+            "double": {
+                "type": "number",
+                "value": 99.98
+            },
+            "string": {
+                "type": "string",
+                "value": "Default"
+            },
+            "file": {
+                "type": "file"
+            }
+        }
+    },
+    "Example visual function": {
+        "type": "function",
+        "isVisual": true,
+        "arguments": {
+            "color": {
+                "type": "string",
+                "value": "transparent"
+            },
+            "enabled": {
+                "type": "boolean",
+                "value": false
+            },
+            "image": {
+                "type": "file"
+            }
+        }
     }
-  }
+}

--- a/Example/package.json
+++ b/Example/package.json
@@ -25,7 +25,8 @@
     "react-native-safe-area-context": "^3.2.0",
     "react-native-screens": "3.31.1",
     "react-native-svg-transformer": "^1.3.0",
-    "react-native-tab-view": "^3.0.1"
+    "react-native-tab-view": "^3.0.1",
+    "react-native-webview": "^13.12.3"
   },
   "devDependencies": {
     "@babel/core": "^7.20.0",

--- a/Example/styles.js
+++ b/Example/styles.js
@@ -1,0 +1,72 @@
+'use strict';
+
+import { StyleSheet } from 'react-native';
+
+module.exports = StyleSheet.create({
+    modalBackground: {
+      flex: 1,
+      justifyContent: 'center',
+      alignItems: 'center',
+      backgroundColor: 'rgba(0, 0, 0, 0.5)',
+    },
+    popupContainer: {
+      width: '80%',
+      padding: 20,
+      backgroundColor: 'white',
+      borderRadius: 10,
+      alignItems: 'center',
+    },
+    title: {
+      fontSize: 18,
+      fontWeight: 'bold',
+      marginBottom: 10,
+    },
+    description: {
+      fontSize: 14,
+      color: 'gray',
+      marginBottom: 20,
+      textAlign: 'center',
+    },
+    inputContainer: {
+      width: '100%'
+    },
+    input: {
+      width: '100%',
+      height: 40,
+      borderColor: 'gray',
+      borderWidth: 1,
+      borderRadius: 5,
+      paddingHorizontal: 10,
+      marginBottom: 20
+    },
+    submitButton: {
+      width: '100%',
+      padding: 10,
+      backgroundColor: '#4CAF50',
+      borderRadius: 5,
+      marginBottom: 20,
+    },
+    buttonContainer: {
+      flexDirection: 'row',
+      justifyContent: 'space-between',
+      width: '100%',
+    },
+    cancelButton: {
+      flex: 1,
+      padding: 10,
+      backgroundColor: '#f44336',
+      borderRadius: 5,
+      marginRight: 10,
+    },
+    confirmButton: {
+      flex: 1,
+      padding: 10,
+      backgroundColor: '#4CAF50',
+      borderRadius: 5,
+      marginLeft: 10,
+    },
+    buttonText: {
+      color: 'white',
+      textAlign: 'center',
+    },
+  });

--- a/android/src/main/java/com/clevertap/react/CleverTapModuleImpl.java
+++ b/android/src/main/java/com/clevertap/react/CleverTapModuleImpl.java
@@ -1142,6 +1142,14 @@ public class CleverTapModuleImpl {
         );
     }
 
+    public void customTemplateContextToString(String templateName, Promise promise) {
+        resolveWithTemplateContext(
+                templateName,
+                promise,
+                templateContext -> templateContext.toString()
+        );
+    }
+
     public void syncCustomTemplates() {
         CleverTapAPI cleverTap = getCleverTapAPI();
         if (cleverTap != null) {

--- a/android/src/newarch/CleverTapModule.kt
+++ b/android/src/newarch/CleverTapModule.kt
@@ -500,6 +500,13 @@ class CleverTapModule(reactContext: ReactApplicationContext?) :
         cleverTapModuleImpl.customTemplateGetObjectArg(templateName, argName, promise)
     }
 
+    override fun customTemplateContextToString(
+        templateName: String?,
+        promise: Promise?
+    ) {
+        cleverTapModuleImpl.customTemplateContextToString(templateName, promise)
+    }
+
     override fun syncCustomTemplates() {
         cleverTapModuleImpl.syncCustomTemplates()
     }

--- a/android/src/oldarch/CleverTapModule.kt
+++ b/android/src/oldarch/CleverTapModule.kt
@@ -588,6 +588,14 @@ class CleverTapModule(reactContext: ReactApplicationContext?) :
     }
 
     @ReactMethod
+    fun customTemplateContextToString(
+        templateName: String?,
+        promise: Promise?
+    ) {
+        cleverTapModuleImpl.customTemplateContextToString(templateName, promise)
+    }
+
+    @ReactMethod
     fun syncCustomTemplates() {
         cleverTapModuleImpl.syncCustomTemplates()
     }

--- a/ios/CleverTapReact/CleverTapReact.mm
+++ b/ios/CleverTapReact/CleverTapReact.mm
@@ -1119,6 +1119,14 @@ RCT_EXPORT_METHOD(customTemplateSetPresented:(NSString *)templateName
     }];
 }
 
+RCT_EXPORT_METHOD(customTemplateContextToString:(NSString *)templateName
+                           resolve:(RCTPromiseResolveBlock)resolve
+                            reject:(RCTPromiseRejectBlock)reject) {
+    [self resolveWithTemplateContext:templateName resolve:resolve reject:reject block:^id(CTTemplateContext *context) {
+        return [context debugDescription];
+    }];
+}
+
 - (void)resolveWithTemplateContext:(NSString *)templateName
                            resolve:(RCTPromiseResolveBlock)resolve
                             reject:(RCTPromiseRejectBlock)reject

--- a/src/NativeCleverTapModule.ts
+++ b/src/NativeCleverTapModule.ts
@@ -202,6 +202,7 @@ export interface Spec extends TurboModule {
   customTemplateGetBooleanArg(templateName: string, argName: string): Promise<boolean>;
   customTemplateGetFileArg(templateName: string, argName: string): Promise<string>;
   customTemplateGetObjectArg(templateName: string, argName: string): Promise<any>;
+  customTemplateContextToString(templateName: string): Promise<string>;
   syncCustomTemplates(): void;
   syncCustomTemplatesInProd(isProduction: boolean): void;
   promptForPushPermission(showFallbackSettings: boolean): void;

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -802,6 +802,8 @@ export function isPushPermissionGranted(callback: CallbackString): void;
 
   export function customTemplateGetObjectArg(templateName: string, argName: string): Promise<any>;
 
+  export function customTemplateContextToString(templateName: string): Promise<string>;
+
   /*******************
    * Developer Options
    ******************/

--- a/src/index.js
+++ b/src/index.js
@@ -1014,7 +1014,11 @@ var CleverTap = {
     },
 
     customTemplateGetObjectArg: function (templateName, argName) {
-        return CleverTapReact.customTemplateGetObjectArg(templateName, argName)
+        return CleverTapReact.customTemplateGetObjectArg(templateName, argName);
+    },
+
+    customTemplateContextToString: function (templateName) {
+        return CleverTapReact.customTemplateContextToString(templateName);
     }
 };
 


### PR DESCRIPTION
## Overview
Adds Custom Templates and UI in the Example app.
Adds `CleverTap.customTemplateContextToString(templateName)` to the SDK to get the `TemplateContext` description.

## Implementation
- Adds an `InAppMessagePopup` to display a modal for Custom Templates and standalone App Functions.
- Adds a `FunctionPopup` to display a modal for `isVisual:false` App Functions triggered from a Custom Template action.
- Adds `CustomTemplate` to control the modals and presentation. It adds listeners to the CleverTap Custom template events.
- Adds `customTemplateContextToString` which gets the `TemplateContext.toString` on Android and `TemplateContext.debugDescription` on iOS.