### PR TITLE
Fix for Push notification Clicked twice in killed state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 Change Log
 ==========
 
+Version 3.1.1 *(6 November 2024)*
+-------------------------------------------
+**What's new**
+
+* **[iOS Platform]**
+  * Fixes a bug where the push notification callback was getting triggered twice.
+
 Version 3.1.0 *(25 October 2024)*
 -------------------------------------------
 **What's new**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,10 +3,10 @@ Change Log
 
 Version 3.1.1 *(6 November 2024)*
 -------------------------------------------
-**What's new**
+**Bug Fixes**
 
 * **[iOS Platform]**
-  * Fixes a bug where the push notification callback was getting triggered twice.
+  * Fixes a bug where the push notification callback was getting triggered twice in killed state.
 
 Version 3.1.0 *(25 October 2024)*
 -------------------------------------------

--- a/Example/package-lock.json
+++ b/Example/package-lock.json
@@ -49,7 +49,7 @@
       }
     },
     "..": {
-      "version": "3.1.0",
+      "version": "3.1.1",
       "license": "MIT",
       "devDependencies": {
         "eslint": "^4.18.2",

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -35,8 +35,8 @@ android {
     defaultConfig {
         minSdkVersion 19
         targetSdkVersion 34
-        versionCode 310
-        versionName "3.1.0"
+        versionCode 311
+        versionName "3.1.1"
         buildConfigField("boolean", "IS_NEW_ARCHITECTURE_ENABLED", isNewArchitectureEnabled().toString())
     }
 

--- a/ios/CleverTapReact/CleverTapReactManager.h
+++ b/ios/CleverTapReact/CleverTapReactManager.h
@@ -10,6 +10,5 @@
 - (void)setDelegates:(CleverTap *)cleverTapInstance;
 
 @property NSString *launchDeepLink;
-@property(nonatomic, strong) NSDictionary *pendingPushNotificationExtras;
 
 @end

--- a/ios/CleverTapReact/CleverTapReactManager.mm
+++ b/ios/CleverTapReact/CleverTapReactManager.mm
@@ -38,11 +38,6 @@
 - (instancetype)init {
     self = [super init];
     if (self) {
-        
-        [[NSNotificationCenter defaultCenter] addObserver:self
-                                                 selector:@selector(handleContentDidAppearNotification:)
-                                                     name:RCTContentDidAppearNotification
-                                                   object:nil];
         CleverTap *clevertap = [CleverTap sharedInstance];
         [self setDelegates:clevertap];
     }
@@ -169,17 +164,6 @@
     NSMutableDictionary *body = [NSMutableDictionary new];
     body[@"accepted"] = [NSNumber numberWithBool:accepted];
     [self postNotificationWithName:kCleverTapPushPermissionResponseReceived andBody:body];
-}
-
-- (void)handleContentDidAppearNotification:(NSNotification *)notification {
-    [[NSNotificationCenter defaultCenter] removeObserver:self];
-    
-    NSMutableDictionary *pushNotificationExtras = [NSMutableDictionary new];
-    NSDictionary *customExtras = self.pendingPushNotificationExtras;
-    if (customExtras != nil) {
-        pushNotificationExtras = [NSMutableDictionary dictionaryWithDictionary:customExtras];
-        [self  postNotificationWithName:kCleverTapPushNotificationClicked andBody:pushNotificationExtras];
-    }
 }
 
 @end

--- a/ios/CleverTapReact/CleverTapReactManager.mm
+++ b/ios/CleverTapReact/CleverTapReactManager.mm
@@ -58,7 +58,6 @@
 - (void)applicationDidLaunchWithOptions:(NSDictionary *)options {
     NSDictionary *notification = [options valueForKey:UIApplicationLaunchOptionsRemoteNotificationKey];
     if (notification){
-        self.pendingPushNotificationExtras = notification;
         if (notification[@"wzrk_dl"]) {
             self.launchDeepLink = notification[@"wzrk_dl"];
             RCTLogInfo(@"CleverTapReact: setting launch deeplink: %@", self.launchDeepLink);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "clevertap-react-native",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "clevertap-react-native",
-      "version": "3.1.0",
+      "version": "3.1.1",
       "license": "MIT",
       "devDependencies": {
         "eslint": "^4.18.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clevertap-react-native",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "description": "CleverTap React Native SDK.",
   "main": "src/index.js",
   "types": "src/index.d.ts",

--- a/src/index.js
+++ b/src/index.js
@@ -12,7 +12,7 @@ const EventEmitter = Platform.select({
 * @param {int} libVersion - The updated library version. If current version is 1.1.0 then pass as 10100  
 */
 const libName = 'React-Native';
-const libVersion = 30100;
+const libVersion = 30101;
 CleverTapReact.setLibrary(libName,libVersion);
 
 function defaultCallback(method, err, res) {


### PR DESCRIPTION
| What           | Where/Who                         |
|----------------|-----------------------------------|
| JIRA Issue     | [SDK-4108](https://wizrocket.atlassian.net/browse/SDK-4108)                           |
| People Involved| [@akashvercetti](https://github.com/akashvercetti) [@kushCT](https://github.com/kushCT)  |


## Background

The callback for push notification is triggered twice when the application is in killed state

## Implementation

- Removed `handleContentDidAppearNotification` method where the listeners to the same callback was getting attached for the second time

## Testing steps

Manual.

## Is this change backwards-compatible?

No.

[SDK-4108]: https://wizrocket.atlassian.net/browse/SDK-4108?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ