### PR TITLE
Task/sdk 4375/buffer_synchronisation

### DIFF
--- a/android/src/main/java/com/clevertap/react/CleverTapEventEmitter.kt
+++ b/android/src/main/java/com/clevertap/react/CleverTapEventEmitter.kt
@@ -57,9 +57,11 @@ object CleverTapEventEmitter {
      */
     fun flushBuffer(event: CleverTapEvent) {
         val buffer = eventsBuffers[event] ?: return
-        while (buffer.size() > 0) {
-            val params = buffer.remove()
-            sendEvent(event, params)
+        synchronized(buffer) {
+            while (buffer.size() > 0) {
+                val params = buffer.remove()
+                sendEvent(event, params)
+            }
         }
     }
 


### PR DESCRIPTION
Synchronises element removal to help with concurrency

This is a theoretical fix. Couldn't be reproduced on the sample app