### PR TITLE
task(SDK-5150): Adds support for iOS(7.3.3) and android(7.5.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,19 @@
 Change Log
 ==========
 
+Version 3.7.0 *(Oct 3 2025)*
+-------------------------------------------
+**What's new**
+* **[Android Platform]**
+  * Supports [CleverTap Android SDK v7.5.2](https://github.com/CleverTap/clevertap-android-sdk/blob/master/docs/CTCORECHANGELOG.md#version-752-september-11-2025).
+
+* **[iOS Platform]**
+  * Supports [CleverTap iOS SDK v7.3.3](https://github.com/CleverTap/clevertap-ios-sdk/blob/master/CHANGELOG.md#version-733-september-11-2025).
+
+**API changes**
+* **[Android and iOS Platform]**
+  * Adds support for the DOB key to accept either a Date object or a string in the format 'yyyy-mm-dd', ensuring backward compatibility.
+
 Version 3.6.0 *(July 17 2025)*
 -------------------------------------------
 **What's new**

--- a/clevertap-react-native.podspec
+++ b/clevertap-react-native.podspec
@@ -24,7 +24,7 @@ Pod::Spec.new do |s|
     s.dependency 'React-Core'
   end
 
-  s.dependency 'CleverTap-iOS-SDK', '7.3.1'
+  s.dependency 'CleverTap-iOS-SDK', '7.3.3'
 
   if ENV['RCT_NEW_ARCH_ENABLED'] == '1' then
     s.pod_target_xcconfig = {

--- a/ios/CleverTapReact/CleverTapReact.mm
+++ b/ios/CleverTapReact/CleverTapReact.mm
@@ -570,7 +570,6 @@ RCT_EXPORT_METHOD(setDebugLevel:(double)level) {
             NSDate *dob = nil;
             
             if([value isKindOfClass:[NSString class]] && ![value hasPrefix:@"$D_"]) {
-
                 if(!dateFormatter) {
                     dateFormatter = [[NSDateFormatter alloc] init];
                     [dateFormatter setDateFormat:@"yyyy-MM-dd"];

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clevertap-react-native",
-  "version": "3.6.0",
+  "version": "3.7.0",
   "description": "CleverTap React Native SDK.",
   "main": "src/index.js",
   "types": "src/index.d.ts",


### PR DESCRIPTION
Adds support for iOS(7.3.3) and android(7.5.2)
Adds dob parsing support in iOS

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Releases 3.7.0 updating iOS to 7.3.3 and Android to 7.5.2, and refines iOS profile DOB parsing to handle yyyy-mm-dd strings while ignoring $D_-prefixed values.
> 
> - **Release 3.7.0**
>   - Updates support to `CleverTap Android SDK v7.5.2` and `CleverTap iOS SDK v7.3.3`.
>   - Bumps iOS pod dependency to `CleverTap-iOS-SDK 7.3.3` and package version to `3.7.0`.
> - **iOS**
>   - `ios/CleverTapReact/CleverTapReact.mm`: Refines `DOB` parsing in `formatProfile` to accept `yyyy-MM-dd` strings or dates, and skip parsing for strings prefixed with `$D_` to preserve special values.
> - **Docs**
>   - `CHANGELOG.md`: Adds 3.7.0 notes and API update for `DOB` handling.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a3046acf537303f6a615b213b44780af39245118. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->