### PR TITLE
task(SDK-6101): release v4.3.1

### DIFF
--- a/Example/package-lock.json
+++ b/Example/package-lock.json
@@ -50,7 +50,7 @@
     },
     "..": {
       "name": "clevertap-react-native",
-      "version": "4.3.0",
+      "version": "4.3.1",
       "license": "MIT",
       "devDependencies": {
         "eslint": "^4.18.2",

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -35,8 +35,8 @@ android {
     defaultConfig {
         minSdkVersion 23
         targetSdkVersion 36
-        versionCode 430
-        versionName "4.3.0"
+        versionCode 431
+        versionName "4.3.1"
         buildConfigField("boolean", "IS_NEW_ARCHITECTURE_ENABLED", isNewArchitectureEnabled().toString())
     }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "clevertap-react-native",
-  "version": "4.3.0",
+  "version": "4.3.1",
   "description": "CleverTap React Native SDK.",
   "main": "src/index.js",
   "types": "src/index.d.ts",

--- a/src/index.js
+++ b/src/index.js
@@ -12,7 +12,7 @@ const EventEmitter = Platform.select({
 * @param {int} libVersion - The updated library version. If current version is 1.1.0 then pass as 10100  
 */
 const libName = 'React-Native';
-const libVersion = 40300;
+const libVersion = 40301;
 CleverTapReact.setLibrary(libName,libVersion);
 
 function defaultCallback(method, err, res) {


### PR DESCRIPTION
 ## Release v4.3.1

  Version bump for the 4.3.1 patch release. No API or native SDK changes in this PR.

  ### What's in 4.3.1

  Android bug fixes already merged to `develop` via #515 (SDK-6021):
  - Fixes a crash at app startup when a listener is registered while the SDK is still delivering events (event buffer is now locked on writes as
  well as drains).
  - Fixes a crash and occasional loss of remote-config variables when they are defined while updated values arrive from the server (now held in a
  thread-safe map).

  Also includes the npm package size reduction from #516 (SDK-6094):using `package.json` `files[]` instead of `.npmignore`

  ### Version bump

  | File | Change |
  |---|---|
  | `package.json` | 4.3.0 → 4.3.1 |
  | `android/build.gradle` | versionCode 430 → 431, versionName 4.3.0 → 4.3.1 |
  | `src/index.js` | libVersion 40300 → 40301 |
  | `Example/package-lock.json` | SDK entry 4.3.0 → 4.3.1 |

  ### CHANGELOG

  4.3.1 entry (September 3 2026) is already on `develop` from #515.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the library release version to 4.3.1 across supported platforms.
  * Updated the Android version code for the latest release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->