### PR TITLE
task(SDK-6101): clarify startup crash wording in 4.3.1 changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ Version 4.3.1 *(September 3 2026)*
 -------------------------------------------
 **Bug Fixes**
 * **[Android Platform]**
-  * Fixes a crash at app startup that occurs when a listener is registered while the SDK is still delivering events, by locking the event buffer on writes as well as drains.
+  * Fixes a rare crash at app startup that could occur when a listener is registered at the same moment the SDK is delivering buffered events, by locking the event buffer on writes as well as drains.
   * Fixes a crash and occasional loss of remote-config variables when they are defined while updated values arrive from the server, by holding them in a thread-safe map.
 
 Version 4.3.0 *(August 20 2026)*


### PR DESCRIPTION
Reword the 4.3.1 startup crash entry to say it was a rare, timing-dependent crash. No code change.